### PR TITLE
tweaks for random support

### DIFF
--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -389,15 +389,15 @@ library Impl {
     /// @param uintType the type of the random value to generate
     /// @param seed the seed to use to create a random value from
     /// @param securityZone the security zone to use for the random value
-    function random(uint8 uintType, uint64 seed, int32 securityZone) internal returns (uint256) {
-        return ITaskManager(TASK_MANAGER_ADDRESS).createTask(uintType, FunctionId.random, new uint256[](0), Common.createUint256Inputs(seed, Common.convertInt32ToUint256(securityZone)));
+    function random(uint8 uintType, uint256 seed, int32 securityZone) internal returns (uint256) {
+        return ITaskManager(TASK_MANAGER_ADDRESS).createRandomTask(uintType, seed, securityZone);
     }
 
     /// @notice Generates a random value of a given type with the given seed
     /// @dev Calls the desired function
     /// @param uintType the type of the random value to generate
     /// @param seed the seed to use to create a random value from
-    function random(uint8 uintType, uint32 seed) internal returns (uint256) {
+    function random(uint8 uintType, uint256 seed) internal returns (uint256) {
         return random(uintType, seed, 0);
     }
 
@@ -407,7 +407,6 @@ library Impl {
     function random(uint8 uintType) internal returns (uint256) {
         return random(uintType, 0, 0);
     }
-
 }
 
 library FHE {

--- a/contracts/ICofhe.sol
+++ b/contracts/ICofhe.sol
@@ -38,6 +38,7 @@ enum FunctionId {
 
 interface ITaskManager {
     function createTask(uint8 returnType, FunctionId funcId, uint256[] memory encryptedInputs, uint256[] memory extraInputs) external returns (uint256);
+    function createRandomTask(uint8 returnType, uint256 seed, int32 securityZone) external returns (uint256);
 
     function createDecryptTask(uint256 ctHash, address requestor) external;
     function createSealOutputTask(uint256 ctHash, bytes32 publicKey, address requestor) external;


### PR DESCRIPTION
I tweaked a little bit the library so that it calls the createRandomTask that the TaskManager supports. (also seed param for task is now 256 instead of 64).

minor note: the branch is named random-0.0.5 because I branched out from that version but it was updated since with master.

compatible with:
Task Manager: https://github.com/FhenixProtocol/copro-task-manager-hardhat/pull/43
Fheos: https://github.com/FhenixProtocol/fheos/pull/233
cofhe monorepo which includes a runCopro.sh change to use this repo inside the taskmanager: https://github.com/FhenixProtocol/cofhe/pull/148