### PR TITLE
[FEAT] Add ERC-2771 meta-transaction support to TaskManager

### DIFF
--- a/RFC_ERC2771_META_TRANSACTIONS.md
+++ b/RFC_ERC2771_META_TRANSACTIONS.md
@@ -1,0 +1,96 @@
+# RFC: ERC-2771 Meta-Transaction Support
+
+## Summary
+
+Add ERC-2771 meta-transaction support to `TaskManager.sol` to enable relayer patterns where encrypted inputs are created client-side but submitted via a trusted forwarder.
+
+## Motivation
+
+Current FHE encryption is cryptographically bound to `msg.sender`. The ZK proof embeds the wallet address, and on-chain verification requires the submitting wallet to match. This blocks relayer patterns where:
+
+- User encrypts client-side (browser/mobile)
+- Relayer submits transaction (via gas sponsorship service)
+
+Use cases:
+- Circle Gas Station integration
+- Programmable Wallet abstraction
+- Gasless transactions for better UX
+
+## Technical Approach
+
+### ERC-2771 Standard
+
+[ERC-2771](https://eips.ethereum.org/EIPS/eip-2771) (Secure Protocol for Native Meta Transactions) is the OpenZeppelin standard for meta-transactions. The key insight is that `_msgSender()` handles both direct calls AND meta-transactions transparently:
+
+| Call Type | `msg.sender` | `_msgSender()` |
+|-----------|--------------|----------------|
+| Direct | User EOA | User EOA |
+| Via Forwarder | Forwarder contract | Original user (from calldata) |
+
+### Implementation
+
+Added to `TaskManager.sol`:
+
+```solidity
+/// @notice Trusted forwarder for ERC-2771 meta-transactions
+address private _trustedForwarder;
+
+function trustedForwarder() public view virtual returns (address) {
+    return _trustedForwarder;
+}
+
+function isTrustedForwarder(address forwarder) public view virtual returns (bool) {
+    return forwarder == _trustedForwarder;
+}
+
+function setTrustedForwarder(address forwarder) external onlyOwner {
+    _trustedForwarder = forwarder;
+}
+
+function _msgSender() internal view virtual override returns (address) {
+    uint256 calldataLength = msg.data.length;
+    uint256 contextSuffixLength = _contextSuffixLength();
+    if (isTrustedForwarder(msg.sender) && calldataLength >= contextSuffixLength) {
+        return address(bytes20(msg.data[calldataLength - contextSuffixLength:]));
+    }
+    return super._msgSender();
+}
+
+function _msgData() internal view virtual override returns (bytes calldata) {
+    uint256 calldataLength = msg.data.length;
+    uint256 contextSuffixLength = _contextSuffixLength();
+    if (isTrustedForwarder(msg.sender) && calldataLength >= contextSuffixLength) {
+        return msg.data[:calldataLength - contextSuffixLength];
+    }
+    return super._msgData();
+}
+
+function _contextSuffixLength() internal view virtual returns (uint256) {
+    return 20; // address length
+}
+```
+
+All functions that previously used `msg.sender` for sender verification now use `_msgSender()`:
+- `checkAllowed()`
+- `createRandomTask()`
+- `createTask()`
+- `verifyInput()`
+- `allow()`, `allowGlobal()`, `allowTransient()`, `allowForDecryption()`
+
+## Security Considerations
+
+1. **Trusted Forwarder Only**: Only a single owner-configurable trusted forwarder can append sender addresses to calldata
+2. **Backwards Compatible**: Direct calls work exactly as before (when `msg.sender != trustedForwarder`)
+3. **Signature Verification**: The trusted forwarder (e.g., OpenZeppelin's `ERC2771Forwarder`) is responsible for verifying user signatures before forwarding
+
+## Migration
+
+1. Deploy updated `TaskManager` implementation
+2. Configure trusted forwarder address via `setTrustedForwarder()`
+3. Relayers submit transactions through the forwarder contract
+
+## References
+
+- [ERC-2771 Specification](https://eips.ethereum.org/EIPS/eip-2771)
+- [OpenZeppelin ERC2771Context](https://docs.openzeppelin.com/contracts/5.x/api/metatx#ERC2771Context)
+- [OpenZeppelin ERC2771Forwarder](https://docs.openzeppelin.com/contracts/5.x/api/metatx#ERC2771Forwarder)

--- a/contracts/internal/host-chain/test/taskManager/TaskManager.behavior.ts
+++ b/contracts/internal/host-chain/test/taskManager/TaskManager.behavior.ts
@@ -1,0 +1,99 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+export function shouldBehaveLikeTaskManagerERC2771(): void {
+  describe("ERC-2771 Meta-Transaction Support", function () {
+    it("should have no trusted forwarder by default", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+
+      const forwarder = await taskManager.trustedForwarder();
+      expect(forwarder).to.equal(hre.ethers.ZeroAddress);
+    });
+
+    it("should correctly report isTrustedForwarder as false for zero address", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+
+      const isTrusted = await taskManager.isTrustedForwarder(hre.ethers.ZeroAddress);
+      expect(isTrusted).to.equal(false);
+    });
+
+    it("should correctly report isTrustedForwarder as false for random address", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+      const randomAddress = "0x1234567890123456789012345678901234567890";
+
+      const isTrusted = await taskManager.isTrustedForwarder(randomAddress);
+      expect(isTrusted).to.equal(false);
+    });
+
+    it("should allow owner to set trusted forwarder", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+      const forwarderAddress = "0x1234567890123456789012345678901234567890";
+
+      await taskManager.setTrustedForwarder(forwarderAddress);
+
+      const forwarder = await taskManager.trustedForwarder();
+      expect(forwarder).to.equal(forwarderAddress);
+    });
+
+    it("should correctly report isTrustedForwarder after setting", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+      const forwarderAddress = "0x1234567890123456789012345678901234567890";
+
+      await taskManager.setTrustedForwarder(forwarderAddress);
+
+      const isTrusted = await taskManager.isTrustedForwarder(forwarderAddress);
+      expect(isTrusted).to.equal(true);
+
+      // Other addresses should still be false
+      const otherAddress = "0x9876543210987654321098765432109876543210";
+      const isOtherTrusted = await taskManager.isTrustedForwarder(otherAddress);
+      expect(isOtherTrusted).to.equal(false);
+    });
+
+    it("should allow owner to update trusted forwarder", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+      const forwarderAddress1 = "0x1234567890123456789012345678901234567890";
+      const forwarderAddress2 = "0x9876543210987654321098765432109876543210";
+
+      await taskManager.setTrustedForwarder(forwarderAddress1);
+      expect(await taskManager.trustedForwarder()).to.equal(forwarderAddress1);
+
+      await taskManager.setTrustedForwarder(forwarderAddress2);
+      expect(await taskManager.trustedForwarder()).to.equal(forwarderAddress2);
+
+      // First forwarder should no longer be trusted
+      expect(await taskManager.isTrustedForwarder(forwarderAddress1)).to.equal(false);
+      expect(await taskManager.isTrustedForwarder(forwarderAddress2)).to.equal(true);
+    });
+
+    it("should allow owner to clear trusted forwarder by setting to zero address", async function () {
+      const taskManager = this.taskManager.connect(this.signers.admin);
+      const forwarderAddress = "0x1234567890123456789012345678901234567890";
+
+      await taskManager.setTrustedForwarder(forwarderAddress);
+      expect(await taskManager.trustedForwarder()).to.equal(forwarderAddress);
+
+      await taskManager.setTrustedForwarder(hre.ethers.ZeroAddress);
+      expect(await taskManager.trustedForwarder()).to.equal(hre.ethers.ZeroAddress);
+      expect(await taskManager.isTrustedForwarder(forwarderAddress)).to.equal(false);
+    });
+
+    it("should revert when non-owner tries to set trusted forwarder", async function () {
+      // Get a non-owner signer
+      const signers = await hre.ethers.getSigners();
+      const nonOwner = signers[1];
+
+      if (!nonOwner) {
+        console.log("Skipping test: no second signer available");
+        return;
+      }
+
+      const taskManager = this.taskManager.connect(nonOwner);
+      const forwarderAddress = "0x1234567890123456789012345678901234567890";
+
+      await expect(
+        taskManager.setTrustedForwarder(forwarderAddress)
+      ).to.be.revertedWithCustomError(taskManager, "OwnableUnauthorizedAccount");
+    });
+  });
+}

--- a/contracts/internal/host-chain/test/taskManager/TaskManager.fixture.ts
+++ b/contracts/internal/host-chain/test/taskManager/TaskManager.fixture.ts
@@ -1,0 +1,29 @@
+import type { TaskManager } from "../../types";
+import hre from "hardhat";
+
+export async function deployTaskManagerFixture(): Promise<{
+  taskManager: TaskManager;
+  taskManagerAddress: string;
+}> {
+  // Run deploy scripts to set up TaskManager
+  await hre.run("deploy");
+
+  // Get the deployed TaskManager
+  const taskManagerAddress = "0xeA30c4B8b44078Bbf8a6ef5b9f1eC1626C7848D9";
+  const taskManager = await hre.ethers.getContractAt("TaskManager", taskManagerAddress);
+
+  return { taskManager, taskManagerAddress };
+}
+
+export async function getTokensFromFaucet() {
+  if (hre.network.name === "localfhenix") {
+    const signers = await hre.ethers.getSigners();
+
+    if (
+      (await hre.ethers.provider.getBalance(signers[0].address)).toString() ===
+      "0"
+    ) {
+      await hre.fhenixjs.getFunds(signers[0].address);
+    }
+  }
+}

--- a/contracts/internal/host-chain/test/taskManager/TaskManager.ts
+++ b/contracts/internal/host-chain/test/taskManager/TaskManager.ts
@@ -1,0 +1,25 @@
+import type { Signers } from "../types";
+import { shouldBehaveLikeTaskManagerERC2771 } from "./TaskManager.behavior";
+import { deployTaskManagerFixture, getTokensFromFaucet } from "./TaskManager.fixture";
+import hre from "hardhat";
+
+describe("TaskManager Tests", function () {
+  before(async function () {
+    this.signers = {} as Signers;
+
+    // get tokens from faucet if we're on localfhenix and don't have a balance
+    await getTokensFromFaucet();
+
+    const { taskManager, taskManagerAddress } = await deployTaskManagerFixture();
+    this.taskManager = taskManager;
+    this.taskManagerAddress = taskManagerAddress;
+
+    // set admin account/signer
+    const signers = await hre.ethers.getSigners();
+    this.signers.admin = signers[0];
+  });
+
+  describe("TaskManager", function () {
+    shouldBehaveLikeTaskManagerERC2771();
+  });
+});


### PR DESCRIPTION
- Add trusted forwarder configuration (setTrustedForwarder, trustedForwarder, isTrustedForwarder)
- Override _msgSender() and _msgData() for meta-transaction support
- Replace msg.sender with _msgSender() in verification functions
- Add unit tests for ERC-2771 functionality
- Add RFC documentation

This enables meta-transaction patterns where users can encrypt client-side and have relayers submit transactions via a trusted forwarder.