### PR TITLE
[CI] Migrate release pipeline from npm token to oidc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @fhenixprotocol/protocol-team team will be requested for review when someone 
+# opens a pull request.
+*       @fhenixprotocol/protocol-team

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Publish Cofhe Contracts Package to npmjs
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read
+  id-token: write  # Required for NPM provenance
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -32,5 +37,3 @@ jobs:
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
       - run: cd contracts && pnpm publish --no-git-checks ${{ env.PRERELEASE }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"


### PR DESCRIPTION
Relevant docs - https://docs.npmjs.com/trusted-publishers