### PR TITLE
Fix trusted publishing using OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && npm publish --provenance --access public ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC
+      - run: cd contracts && npm publish --provenance --access public --tag test  # TEMPORARY: testing OIDC with test tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          registry-url: 'https://registry.npmjs.org/'
+          # Note: NOT setting registry-url so npm can use OIDC natively
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -39,5 +39,3 @@ jobs:
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
       - run: cd contracts && npm publish --provenance --access public ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC
-        env:
-          NODE_AUTH_TOKEN: ''  # Explicitly clear to force OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x  # Node 22 ships with npm 11.x needed for OIDC
           # Note: NOT setting registry-url so npm can use OIDC natively
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest  # Ensure npm >= 11.5 for trusted publishing
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && pnpm publish --no-git-checks --provenance --dry-run ${{ env.PRERELEASE }}  # TEMPORARY: --dry-run for testing - remove before merge
+      - run: cd contracts && pnpm publish --no-git-checks --provenance ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC with test version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,4 @@ jobs:
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && pnpm publish --no-git-checks ${{ env.PRERELEASE }}
+      - run: cd contracts && pnpm publish --no-git-checks --provenance ${{ env.PRERELEASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Publish Cofhe Contracts Package to npmjs
 on:
   release:
     types: [published]
+  pull_request:  # TEMPORARY: for testing OIDC - remove before merge
+    branches: [master]
 
 permissions:
   contents: read
@@ -36,4 +38,4 @@ jobs:
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && pnpm publish --no-git-checks --provenance ${{ env.PRERELEASE }}
+      - run: cd contracts && pnpm publish --no-git-checks --provenance --dry-run ${{ env.PRERELEASE }}  # TEMPORARY: --dry-run for testing - remove before merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Publish Cofhe Contracts Package to npmjs
 on:
   release:
     types: [published]
-  push:  # TEMPORARY: for testing - remove before merge
-    branches: [fix/npm-oidc-provenance]
 
 permissions:
   contents: read
@@ -34,7 +32,7 @@ jobs:
       - name: Determine prerelease tag
         id: prerelease_check
         run: |
-          if [[ "${{ env.VERSION }}" =~ \-(alpha|beta|test)\.[0-9]+$ ]]; then
+          if [[ "${{ env.VERSION }}" =~ \-(alpha|beta)\.[0-9]+$ ]]; then
             echo "PRERELEASE=--tag beta" >> $GITHUB_ENV
           else
             echo "PRERELEASE=" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,6 @@ jobs:
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && npm publish --provenance --access public ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC with npm instead of pnpm
+      - run: cd contracts && npm publish --provenance --access public ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC
+        env:
+          NODE_AUTH_TOKEN: ''  # Explicitly clear to force OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Publish Cofhe Contracts Package to npmjs
 on:
   release:
     types: [published]
-  pull_request:  # TEMPORARY: for testing OIDC - remove before merge
-    branches: [master]
+  push:  # TEMPORARY: for testing OIDC - remove before merge
+    branches: [fix/npm-oidc-provenance]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,12 @@ name: Publish Cofhe Contracts Package to npmjs
 on:
   release:
     types: [published]
-  push:  # TEMPORARY: for testing OIDC - remove before merge
+  push:  # TEMPORARY: for testing - remove before merge
     branches: [fix/npm-oidc-provenance]
 
 permissions:
   contents: read
-  id-token: write  # Required for NPM provenance
+  id-token: write  # Required for NPM OIDC trusted publishing
 
 jobs:
   publish:
@@ -16,10 +16,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x  # Node 22 ships with npm 11.x needed for OIDC
-          # Note: NOT setting registry-url so npm can use OIDC natively
+          node-version: 22.x  # Node 22 for npm 11.x (OIDC requires npm >= 11.5)
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest  # Ensure npm >= 11.5 for trusted publishing
+        run: npm install -g npm@latest
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -27,7 +26,7 @@ jobs:
           run_install: false
       - name: Install deps
         run: cd contracts && pnpm install
-      
+
       - name: Read package version
         id: package_version
         run: echo "VERSION=$(jq -r .version < ./contracts/package.json)" >> $GITHUB_ENV
@@ -35,9 +34,10 @@ jobs:
       - name: Determine prerelease tag
         id: prerelease_check
         run: |
-          if [[ "${{ env.VERSION }}" =~ \-(alpha|beta)\.[0-9]+$ ]]; then
+          if [[ "${{ env.VERSION }}" =~ \-(alpha|beta|test)\.[0-9]+$ ]]; then
             echo "PRERELEASE=--tag beta" >> $GITHUB_ENV
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && npm publish --provenance --access public --tag test  # TEMPORARY: testing OIDC with test tag
+      - name: Publish to npm
+        run: cd contracts && pnpm publish --no-git-checks ${{ env.PRERELEASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           else
             echo "PRERELEASE=" >> $GITHUB_ENV
           fi
-      - run: cd contracts && pnpm publish --no-git-checks --provenance ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC with test version
+      - run: cd contracts && npm publish --provenance --access public ${{ env.PRERELEASE }}  # TEMPORARY: testing OIDC with npm instead of pnpm

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.6",
+	"version": "0.0.14-test.7",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.1",
+	"version": "0.0.14-test.2",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,9 +1,13 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.7",
+	"version": "0.0.14-test.9",
 	"author": {
 		"name": "FhenixProtocol",
+		"url": "https://github.com/FhenixProtocol/cofhe-contracts"
+	},
+	"repository": {
+		"type": "git",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"
 	},
 	"files": [

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14",
+	"version": "0.0.14-test.0",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.0",
+	"version": "0.0.14-test.1",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.4",
+	"version": "0.0.14-test.5",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.3",
+	"version": "0.0.14-test.4",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.5",
+	"version": "0.0.14-test.6",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.2",
+	"version": "0.0.14-test.3",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.0.14-test.9",
+	"version": "0.0.14",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"


### PR DESCRIPTION
Required for npm to use GitHub OIDC token exchange instead of a static npm token.