### PR TITLE
Add allowGlobal to ITaskManager interface

### DIFF
--- a/contracts/internal/host-chain/contracts/detereministic-tm/DeterministicICofhe.sol
+++ b/contracts/internal/host-chain/contracts/detereministic-tm/DeterministicICofhe.sol
@@ -108,6 +108,7 @@ interface ITaskManager {
     function allow(uint256 ctHash, address account) external;
     function isAllowed(uint256 ctHash, address account) external returns (bool);
     function allowTransient(uint256 ctHash, address account) external;
+    function allowGlobal(uint256 ctHash) external;
     function getDecryptResultSafe(uint256 ctHash) external view returns (uint256, bool);
     function getDecryptResult(uint256 ctHash) external view returns (uint256);
 }


### PR DESCRIPTION
The `allowGlobal(uint256 ctHash)` method is implemented in [DeterministicTM.sol](https://github.com/QuantumFUD/cofhe-contracts/blob/master/contracts/internal/host-chain/contracts/detereministic-tm/DeterministicTM.sol), but is missing from the [`ITaskManager`](https://github.com/QuantumFUD/cofhe-contracts/blob/master/contracts/internal/host-chain/contracts/detereministic-tm/DeterministicICofhe.sol) interface. Adding this method to the interface resolves the inconsistency between the interface and the implementation.