### PR TITLE
chore: remove committed solc output artifact with absolute local paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Build artifacts (generated)
+contracts/internal/host-chain/bin/solc-output-compile-all.json


### PR DESCRIPTION
### What changed
This PR removes a generated solc output file that was accidentally committed to the repository and adds it to `.gitignore`.

### Why this matters
The removed file contains machine-specific absolute paths (e.g. `/Users/...`) from a local development environment.
Tracking such build artifacts can:
- Leak local environment details
- Cause noisy and misleading diffs
- Break reproducibility across different machines
- Since this repository publishes packages, committing generated artifacts with absolute paths can also propagate unintended data to downstream consumers.

### Details
- Removed `contracts/internal/host-chain/bin/solc-output-compile-all.json` from git tracking
- Added the file to `.gitignore` to prevent future accidental commits

### Scope
- No functional or contract logic changes
- Repository hygiene and build determinism improvement only