### PR TITLE
[DOCS] Add CTA migration guide and postinstall notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@
 ## v0.1.0 - 2025-02-25
 
 ### Breaking Changes
-- All ciphertext handles are now represented as `bytes32` instead of `uint256`. This doesn't affect contracts that operate on ciphertexts via `FHE.op` functions, since those functions return the wrapped types. It does affect contracts that for some reason do `euintx.unwrap`. The `FHE.op` functions still receive `euintx` inputs, but their underlying types have changed.
+- **Ciphertext handle type change (`uint256` → `bytes32`)**: All encrypted types (`ebool`, `euint8`, `euint16`, `euint32`, `euint64`, `euint128`, `eaddress`) now use `bytes32` as their underlying type instead of `uint256`. This changes the ABI encoding of any function that accepts or returns encrypted types.
+
+### Migration Guide
+
+The `uint256` → `bytes32` type change affects the **compiled ABI** of any contract that exposes encrypted types in its public/external interface. Even if your Solidity code compiles without errors (because the wrapped `euintX` types hide the change), **any off-chain code that interacts with these contracts will break** if it uses stale ABIs or generated types.
+
+#### What breaks
+
+| Scenario | Symptom | Fix |
+|----------|---------|-----|
+| Contract returns `euint64` (e.g. a getter) | ABI now encodes the return as `bytes32` instead of `uint256`. Off-chain calls decode the wrong type and return garbage or revert. | Regenerate ABIs and types (see below) |
+| Contract uses `.unwrap()` on encrypted types | `euint64.unwrap(x)` now returns `bytes32` instead of `uint256`. Solidity compilation fails. | Change `uint256 raw = euint64.unwrap(x)` → `bytes32 raw = euint64.unwrap(x)`. Cast explicitly if you need a `uint256`: `uint256(euint64.unwrap(x))`. |
+| Stored/cached ABI JSON files | Stale ABIs still list `uint256` for encrypted type parameters and return values. Calls will silently encode/decode incorrectly. | Re-compile contracts and re-export ABIs. |
 
 ### Added
 - Support for converting a byte array into a ciphertext. The byte array must be formatted as follows:

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -14,6 +14,9 @@
 		"FHE.sol",
 		"ICofhe.sol"
 	],
+	"scripts": {
+		"postinstall": "node -e \"console.log('\\x1b[31m%s\\x1b[0m', 'Breaking changes detected in v0.1.0: encrypted type handles changed from uint256 to bytes32. You must regenerate ABIs and contract bindings. Migration guide: https://github.com/FhenixProtocol/cofhe-contracts/blob/master/CHANGELOG.md')\""
+	},
 	"keywords": [
 		"blockchain",
 		"ethereum",


### PR DESCRIPTION
## Summary

- Expands the CHANGELOG breaking changes section with a migration guide covering the `uint256` → `bytes32` type change for all encrypted types
- Documents what breaks (ABI encoding, `.unwrap()`, stale ABI JSONs) with a table of scenarios, symptoms, and fixes
- Adds `postinstall` script to `package.json` that prints a red warning about the breaking change with a link to the migration guide

## Note on postinstall

npm v7+ suppresses dependency lifecycle script output by default. The postinstall notice will only be visible to users who install with `--foreground-scripts` or use older npm versions. It's harmless when suppressed.

<img width="1304" height="744" alt="image" src="https://github.com/user-attachments/assets/d292a633-68db-44a7-9f4a-564151c1287f" />
