### PR TITLE
[FEAT] Add CI checks for cofhe-contracts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,231 @@
+name: Checks
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+env:
+  WORKING_DIR: contracts/internal/host-chain
+  KEY: "0x0000000000000000000000000000000000000000000000000000000000000001"
+  KEY2: "0x0000000000000000000000000000000000000000000000000000000000000002"
+  AGGREGATOR_KEY: "0x0000000000000000000000000000000000000000000000000000000000000003"
+
+jobs:
+  lint-solhint:
+    name: Solhint Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts/internal/host-chain
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('contracts/internal/host-chain/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Solhint
+        run: pnpm lint:sol
+
+  storage-layout:
+    name: Storage Layout Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts/internal/host-chain
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('contracts/internal/host-chain/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Compile contracts
+        run: pnpm compile
+
+      - name: Check storage layout
+        run: pnpm storage-layout:check
+
+  contract-size:
+    name: Contract Size Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts/internal/host-chain
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('contracts/internal/host-chain/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Compile contracts
+        run: pnpm compile
+
+      - name: Check contract sizes
+        run: pnpm check:size
+
+  slither:
+    name: Slither Analysis
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts/internal/host-chain
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('contracts/internal/host-chain/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Compile contracts
+        run: pnpm compile
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.4.0
+        with:
+          target: contracts/internal/host-chain
+          solc-version: "0.8.25"
+          slither-config: contracts/internal/host-chain/slither.config.json
+          fail-on: medium
+
+  gas-report:
+    name: Gas Report
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts/internal/host-chain
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('contracts/internal/host-chain/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests with gas reporting
+        run: pnpm test
+        env:
+          REPORT_GAS: "true"
+          GAS_REPORT_FILE: gas-report.txt
+
+      - name: Upload gas report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gas-report
+          path: contracts/internal/host-chain/gas-report.txt
+          retention-days: 30

--- a/contracts/internal/host-chain/.solhint.json
+++ b/contracts/internal/host-chain/.solhint.json
@@ -1,0 +1,13 @@
+{
+  "extends": "solhint:recommended",
+  "rules": {
+    "no-empty-blocks": "off",
+    "no-inline-assembly": "off",
+    "one-contract-per-file": "off",
+    "func-name-mixedcase": "off",
+    "const-name-snakecase": "off",
+    "compiler-version": ["error", ">=0.8.19"],
+    "func-visibility": ["warn", { "ignoreConstructors": true }],
+    "no-unused-import": "warn"
+  }
+}

--- a/contracts/internal/host-chain/.solhintignore
+++ b/contracts/internal/host-chain/.solhintignore
@@ -1,0 +1,3 @@
+node_modules/
+contracts/tests/
+contracts/detereministic-tm/

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -153,7 +153,6 @@ library TMCommon {
 
 contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2StepUpgradeable {
     bool private initialized;
-    uint256 private __test_ci_variable;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -153,6 +153,7 @@ library TMCommon {
 
 contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2StepUpgradeable {
     bool private initialized;
+    uint256 private __test_ci_variable;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -240,7 +240,6 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
     // When set to address(0), signature verification is skipped (debug mode)
     address public decryptResultSigner;
 
-
     modifier onlyAggregator() {
         if (!aggregators[msg.sender]) {
             revert OnlyAggregatorAllowed(msg.sender);

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -101,7 +101,7 @@ library TMCommon {
         uint256[] memory inputs,
         FunctionId functionId
     ) internal pure returns (uint256) {
-        bytes memory combined;
+        bytes memory combined = "";
         bool isTriviallyEncrypted = (functionId == FunctionId.trivialEncrypt);
         for (uint8 i = 0; i < inputs.length; i++) {
             combined = bytes.concat(combined, uint256ToBytes32(inputs[i]));
@@ -632,6 +632,7 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         }
 
         bytes32 messageHash = _computeDecryptResultHash(ctHash, result);
+        // slither-disable-next-line unused-return
         (address recovered, ECDSA.RecoverError err, ) = ECDSA.tryRecover(messageHash, signature);
 
         if (err != ECDSA.RecoverError.NoError || recovered == address(0)) {
@@ -681,6 +682,7 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         emit ProtocolNotification(ctHash, operation, errorMessage);
     }
 
+    // slither-disable-next-line unused-return
     function getDecryptResultSafe(uint256 ctHash) external view returns (uint256, bool) {
         return plaintextsStorage.getResult(ctHash);
     }

--- a/contracts/internal/host-chain/hardhat.config.ts
+++ b/contracts/internal/host-chain/hardhat.config.ts
@@ -129,6 +129,11 @@ const config: HardhatUserConfig = {
     outDir: "types",
     target: "ethers-v6",
   },
+  gasReporter: {
+    enabled: process.env.REPORT_GAS === "true",
+    outputFile: process.env.GAS_REPORT_FILE || undefined,
+    noColors: !!process.env.GAS_REPORT_FILE,
+  },
 };
 
 export default config;

--- a/contracts/internal/host-chain/package.json
+++ b/contracts/internal/host-chain/package.json
@@ -13,7 +13,11 @@
     "task:deploy": "hardhat deploy",
     "deploy:deterministicTM": "hardhat compile && hardhat task:deployDeterministicTM",
     "task:upgradeTM": "hardhat task:upgradeTM",
-    "deploy:sepolia": "hardhat deploy --network sepolia"
+    "deploy:sepolia": "hardhat deploy --network sepolia",
+    "storage-layout:generate": "hardhat task:storage-layout --network hardhat",
+    "storage-layout:check": "hardhat task:storage-layout --network hardhat --check",
+    "check:size": "hardhat task:check-contract-size --network hardhat",
+    "lint:sol": "solhint 'contracts/**/*.sol'"
   },
   "author": "Fhenix",
   "license": "MIT",
@@ -49,6 +53,7 @@
     "hardhat": "^2.28.0",
     "hardhat-deploy": "^0.11.45",
     "hardhat-gas-reporter": "^1.0.10",
+    "solhint": "^5.0.0",
     "mocha": "^10.8.2",
     "rimraf": "^5.0.10",
     "solidity-coverage": "^0.8.17",

--- a/contracts/internal/host-chain/pnpm-lock.yaml
+++ b/contracts/internal/host-chain/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       rimraf:
         specifier: ^5.0.10
         version: 5.0.10
+      solhint:
+        specifier: ^5.0.0
+        version: 5.2.0(typescript@5.9.3)
       solidity-coverage:
         specifier: ^0.8.17
         version: 0.8.17(hardhat@2.28.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))(typescript@5.9.3))
@@ -255,6 +258,14 @@ packages:
     resolution: {integrity: sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@bytecodealliance/preview2-shim@0.17.0':
     resolution: {integrity: sha512-JorcEwe4ud0x5BS/Ar2aQWOQoFzjq/7jcnxYXCvSMh0oRm0dQXzOA+hqLDBnOMks1LLBA7dmiLLsEBl09Yd6iQ==}
 
@@ -382,6 +393,10 @@ packages:
 
   '@fhenixprotocol/contracts@0.2.1':
     resolution: {integrity: sha512-3SQRdpjeQSxZFkhsl8xfARG3bNUEbD23mUmRB2qnGNJHLs9hNQwy8bvqQoJ/3zlhcqMLoDENBKtcP63LzCBe6g==}
+
+  '@humanwhocodes/momoa@2.0.4':
+    resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
+    engines: {node: '>=10.10.0'}
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -619,6 +634,18 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@3.0.2':
+    resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
+    engines: {node: '>=12'}
+
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
@@ -664,6 +691,10 @@ packages:
   '@sentry/utils@5.30.0':
     resolution: {integrity: sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==}
     engines: {node: '>=6'}
+
+  '@sindresorhus/is@5.6.0':
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
 
   '@smithy/abort-controller@4.2.7':
     resolution: {integrity: sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==}
@@ -867,6 +898,10 @@ packages:
   '@solidity-parser/parser@0.20.2':
     resolution: {integrity: sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA==}
 
+  '@szmarczak/http-timer@5.0.1':
+    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
+    engines: {node: '>=14.16'}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -917,6 +952,9 @@ packages:
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
@@ -985,6 +1023,14 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-errors@1.0.1:
+    resolution: {integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==}
+    peerDependencies:
+      ajv: '>=5.0.0'
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
@@ -1030,6 +1076,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  antlr4@4.13.2:
+    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
+    engines: {node: '>=16'}
+
   antlr4ts@0.5.0-alpha.4:
     resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
 
@@ -1067,6 +1117,9 @@ packages:
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  ast-parents@0.0.1:
+    resolution: {integrity: sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1106,6 +1159,12 @@ packages:
 
   bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
+
+  better-ajv-errors@2.0.3:
+    resolution: {integrity: sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==}
+    engines: {node: '>= 18.20.6'}
+    peerDependencies:
+      ajv: 4.11.8 - 8
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -1171,6 +1230,14 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@10.2.14:
+    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
+    engines: {node: '>=14.16'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1182,6 +1249,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
@@ -1287,6 +1358,10 @@ packages:
     resolution: {integrity: sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==}
     engines: {node: '>=8.0.0'}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -1301,12 +1376,24 @@ packages:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
 
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
   cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   create-hash@1.2.0:
     resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
@@ -1340,6 +1427,10 @@ packages:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1350,6 +1441,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -1408,6 +1503,9 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1504,9 +1602,15 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -1584,6 +1688,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@2.1.4:
+    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
+    engines: {node: '>= 14.17'}
+
   form-data@2.5.5:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
@@ -1598,6 +1706,10 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
+    engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1644,6 +1756,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   ghost-testrpc@0.0.2:
     resolution: {integrity: sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==}
     hasBin: true
@@ -1688,6 +1804,13 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@12.6.1:
+    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
+    engines: {node: '>=14.16'}
+
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1765,12 +1888,19 @@ packages:
     resolution: {integrity: sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==}
     engines: {node: '>=6.0.0'}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-response-object@3.0.2:
     resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -1792,6 +1922,10 @@ packages:
 
   immutable@4.3.7:
     resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
 
   imul@1.0.1:
     resolution: {integrity: sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==}
@@ -1817,6 +1951,9 @@ packages:
 
   io-ts@1.10.4:
     resolution: {integrity: sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1887,6 +2024,9 @@ packages:
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -1894,6 +2034,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1916,12 +2065,19 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
   jsonschema@1.5.0:
     resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
 
   keccak@3.0.4:
     resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
     engines: {node: '>=10.0.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -1931,9 +2087,20 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  latest-version@7.0.0:
+    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
+    engines: {node: '>=14.16'}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
   levn@0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
     engines: {node: '>= 0.8.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1961,6 +2128,10 @@ packages:
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2012,6 +2183,14 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -2109,6 +2288,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
   number-to-bn@1.7.0:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
@@ -2138,6 +2321,10 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
+  p-cancelable@3.0.0:
+    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
+    engines: {node: '>=12.20'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2153,8 +2340,20 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-json@8.1.1:
+    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
+    engines: {node: '>=14.16'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-cache-control@1.0.1:
     resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2201,6 +2400,10 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -2227,8 +2430,15 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -2237,12 +2447,20 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -2271,6 +2489,14 @@ packages:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
     engines: {node: '>=6'}
 
+  registry-auth-token@5.1.1:
+    resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
+    engines: {node: '>=14'}
+
+  registry-url@6.0.1:
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
+
   req-cwd@2.0.0:
     resolution: {integrity: sha512-ueoIoLo1OfB6b05COxAA9UpeoscNpYyM+BqYlA7H6LVF4hKGPXQQSSaD2YmvDVJMkk4UDpAHIeU1zG53IqjvlQ==}
     engines: {node: '>=4'}
@@ -2287,8 +2513,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@3.0.0:
     resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
+    engines: {node: '>=4'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
   resolve@1.1.7:
@@ -2301,6 +2534,10 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  responselike@3.0.0:
+    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
+    engines: {node: '>=14.16'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -2435,6 +2672,10 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  solhint@5.2.0:
+    resolution: {integrity: sha512-9NZC1zt+O2K7zEZOhTT9rFeB6GdxC6qTX5pWX70RaQoflR9RejJQUC+/19LNi+e7K9Ptb4k7XAWO9wY5mkprHg==}
+    hasBin: true
+
   solidity-ast@0.4.61:
     resolution: {integrity: sha512-OYBJYcYyG7gLV0VuXl9CUrvgJXjV/v0XnR4+1YomVe3q+QyENQXJJxAEASUz4vN6lMAl+C8RSRSr5MBAz09f6w==}
 
@@ -2506,6 +2747,10 @@ packages:
     resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2547,6 +2792,9 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
   tfhe@0.6.4:
     resolution: {integrity: sha512-80fP2iJJQXrlhyC81u6/aUWMMMDoOXmlY5uqKka2CEd222xM96+z9+FTZc0MjlrR3U+NHja1WOte+A3nlvZkKw==}
@@ -2701,6 +2949,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   utf8@3.0.0:
     resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
@@ -3231,6 +3482,14 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.2': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@bytecodealliance/preview2-shim@0.17.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -3524,6 +3783,8 @@ snapshots:
   '@fhenixprotocol/contracts@0.2.1':
     dependencies:
       '@openzeppelin/contracts': 5.2.0
+
+  '@humanwhocodes/momoa@2.0.4': {}
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -3821,6 +4082,18 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@3.0.2':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
+
   '@scure/base@1.1.9': {}
 
   '@scure/base@1.2.6': {}
@@ -3895,6 +4168,8 @@ snapshots:
     dependencies:
       '@sentry/types': 5.30.0
       tslib: 1.14.1
+
+  '@sindresorhus/is@5.6.0': {}
 
   '@smithy/abort-controller@4.2.7':
     dependencies:
@@ -4212,6 +4487,10 @@ snapshots:
 
   '@solidity-parser/parser@0.20.2': {}
 
+  '@szmarczak/http-timer@5.0.1':
+    dependencies:
+      defer-to-connect: 2.0.1
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -4267,6 +4546,8 @@ snapshots:
     dependencies:
       '@types/minimatch': 6.0.0
       '@types/node': 20.19.27
+
+  '@types/http-cache-semantics@4.2.0': {}
 
   '@types/jsonfile@6.1.4':
     dependencies:
@@ -4329,6 +4610,17 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  ajv-errors@1.0.1(ajv@6.14.0):
+    dependencies:
+      ajv: 6.14.0
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4375,6 +4667,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  antlr4@4.13.2: {}
+
   antlr4ts@0.5.0-alpha.4: {}
 
   anymatch@3.1.3:
@@ -4401,6 +4695,8 @@ snapshots:
   asap@2.0.6: {}
 
   assertion-error@1.1.0: {}
+
+  ast-parents@0.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -4441,6 +4737,15 @@ snapshots:
   base64-js@1.5.1: {}
 
   bech32@1.1.4: {}
+
+  better-ajv-errors@2.0.3(ajv@6.14.0):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@humanwhocodes/momoa': 2.0.4
+      ajv: 6.14.0
+      chalk: 4.1.2
+      jsonpointer: 5.0.1
+      leven: 3.1.0
 
   bignumber.js@9.3.1: {}
 
@@ -4515,6 +4820,18 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@10.2.14:
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      get-stream: 6.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 3.0.0
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4531,6 +4848,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
 
@@ -4655,6 +4974,8 @@ snapshots:
       table-layout: 1.0.2
       typical: 5.2.0
 
+  commander@10.0.1: {}
+
   commander@8.3.0: {}
 
   compare-versions@6.1.1: {}
@@ -4668,9 +4989,23 @@ snapshots:
       readable-stream: 2.3.8
       typedarray: 0.0.6
 
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
   cookie@0.4.2: {}
 
   core-util-is@1.0.3: {}
+
+  cosmiconfig@8.3.6(typescript@5.9.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   create-hash@1.2.0:
     dependencies:
@@ -4709,6 +5044,10 @@ snapshots:
 
   decamelize@4.0.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
@@ -4716,6 +5055,8 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -4771,6 +5112,10 @@ snapshots:
       strip-ansi: 6.0.1
 
   env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-define-property@1.0.1: {}
 
@@ -4937,6 +5282,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-diff@1.3.0: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4944,6 +5291,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
@@ -5026,6 +5375,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@2.1.4: {}
+
   form-data@2.5.5:
     dependencies:
       asynckit: 0.4.0
@@ -5046,6 +5397,12 @@ snapshots:
   fp-ts@1.19.3: {}
 
   fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.3:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -5102,6 +5459,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
 
   ghost-testrpc@0.0.2:
     dependencies:
@@ -5177,6 +5536,22 @@ snapshots:
       slash: 3.0.0
 
   gopd@1.2.0: {}
+
+  got@12.6.1:
+    dependencies:
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
+
+  graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
 
@@ -5330,6 +5705,8 @@ snapshots:
       http-response-object: 3.0.2
       parse-cache-control: 1.0.1
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5341,6 +5718,11 @@ snapshots:
   http-response-object@3.0.2:
     dependencies:
       '@types/node': 10.17.60
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -5361,6 +5743,11 @@ snapshots:
 
   immutable@4.3.7: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
   imul@1.0.1: {}
 
   indent-string@4.0.0: {}
@@ -5379,6 +5766,8 @@ snapshots:
   io-ts@1.10.4:
     dependencies:
       fp-ts: 1.19.3
+
+  is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -5435,6 +5824,8 @@ snapshots:
 
   js-sha3@0.8.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -5443,6 +5834,12 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -5462,6 +5859,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonpointer@5.0.1: {}
+
   jsonschema@1.5.0: {}
 
   keccak@3.0.4:
@@ -5470,14 +5869,26 @@ snapshots:
       node-gyp-build: 4.8.4
       readable-stream: 3.6.2
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  latest-version@7.0.0:
+    dependencies:
+      package-json: 8.1.1
+
+  leven@3.1.0: {}
 
   levn@0.3.0:
     dependencies:
       prelude-ls: 1.1.2
       type-check: 0.3.2
+
+  lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -5501,6 +5912,8 @@ snapshots:
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
+
+  lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -5546,6 +5959,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
 
   minimalistic-assert@1.0.1: {}
 
@@ -5646,6 +6063,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-url@8.1.1: {}
+
   number-to-bn@1.7.0:
     dependencies:
       bn.js: 4.11.6
@@ -5674,6 +6093,8 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
+  p-cancelable@3.0.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -5688,7 +6109,25 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-json@8.1.1:
+    dependencies:
+      got: 12.6.1
+      registry-auth-token: 5.1.1
+      registry-url: 6.0.1
+      semver: 7.7.3
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse-cache-control@1.0.1: {}
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   path-exists@4.0.0: {}
 
@@ -5724,6 +6163,8 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pluralize@8.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   prelude-ls@1.1.2: {}
@@ -5747,13 +6188,19 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  proto-list@1.2.4: {}
+
   proxy-from-env@1.1.0: {}
+
+  punycode@2.3.1: {}
 
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@5.1.1: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -5765,6 +6212,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   readable-stream@2.3.8:
     dependencies:
@@ -5798,6 +6252,14 @@ snapshots:
 
   reduce-flatten@2.0.0: {}
 
+  registry-auth-token@5.1.1:
+    dependencies:
+      '@pnpm/npm-conf': 3.0.2
+
+  registry-url@6.0.1:
+    dependencies:
+      rc: 1.2.8
+
   req-cwd@2.0.0:
     dependencies:
       req-from: 2.0.0
@@ -5810,7 +6272,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@3.0.0: {}
+
+  resolve-from@4.0.0: {}
 
   resolve@1.1.7: {}
 
@@ -5823,6 +6289,10 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@3.0.0:
+    dependencies:
+      lowercase-keys: 3.0.0
 
   retry@0.12.0: {}
 
@@ -5978,6 +6448,34 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  solhint@5.2.0(typescript@5.9.3):
+    dependencies:
+      '@solidity-parser/parser': 0.20.2
+      ajv: 6.14.0
+      ajv-errors: 1.0.1(ajv@6.14.0)
+      antlr4: 4.13.2
+      ast-parents: 0.0.1
+      better-ajv-errors: 2.0.3(ajv@6.14.0)
+      chalk: 4.1.2
+      commander: 10.0.1
+      cosmiconfig: 8.3.6(typescript@5.9.3)
+      fast-diff: 1.3.0
+      fs-extra: 11.3.3
+      glob: 8.1.0
+      ignore: 5.3.2
+      js-yaml: 4.1.1
+      latest-version: 7.0.0
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      semver: 7.7.3
+      strip-ansi: 6.0.1
+      table: 6.9.0
+      text-table: 0.2.0
+    optionalDependencies:
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - typescript
+
   solidity-ast@0.4.61: {}
 
   solidity-coverage@0.8.17(hardhat@2.28.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))(typescript@5.9.3)):
@@ -6070,6 +6568,8 @@ snapshots:
     dependencies:
       is-hex-prefixed: 1.0.0
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strnum@2.1.2: {}
@@ -6116,6 +6616,8 @@ snapshots:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  text-table@0.2.0: {}
 
   tfhe@0.6.4: {}
 
@@ -6263,6 +6765,10 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   utf8@3.0.0: {}
 

--- a/contracts/internal/host-chain/slither.config.json
+++ b/contracts/internal/host-chain/slither.config.json
@@ -3,7 +3,7 @@
   "exclude_informational": true,
   "exclude_optimization": true,
   "exclude_dependencies": true,
-  "detectors_to_exclude": "naming-convention,solc-version,assembly,low-level-calls",
+  "detectors_to_exclude": "naming-convention,solc-version,assembly,low-level-calls,events-maths,missing-zero-check,calls-loop,reentrancy-events,timestamp",
   "hardhat_ignore_compile": true,
   "fail_on": "medium"
 }

--- a/contracts/internal/host-chain/slither.config.json
+++ b/contracts/internal/host-chain/slither.config.json
@@ -1,0 +1,9 @@
+{
+  "filter_paths": "node_modules|contracts/tests|contracts/detereministic-tm",
+  "exclude_informational": true,
+  "exclude_optimization": true,
+  "exclude_dependencies": true,
+  "detectors_to_exclude": "naming-convention,solc-version,assembly,low-level-calls",
+  "hardhat_ignore_compile": true,
+  "fail_on": "medium"
+}

--- a/contracts/internal/host-chain/storage-layout-snapshot.json
+++ b/contracts/internal/host-chain/storage-layout-snapshot.json
@@ -1,0 +1,358 @@
+{
+  "version": 1,
+  "contracts": {
+    "TaskManager": {
+      "storage": [
+        {
+          "label": "initialized",
+          "slot": "0",
+          "offset": 0,
+          "type": "t_bool"
+        },
+        {
+          "label": "securityZoneMax",
+          "slot": "0",
+          "offset": 1,
+          "type": "t_int32"
+        },
+        {
+          "label": "securityZoneMin",
+          "slot": "0",
+          "offset": 5,
+          "type": "t_int32"
+        },
+        {
+          "label": "randomCounter",
+          "slot": "1",
+          "offset": 0,
+          "type": "t_uint256"
+        },
+        {
+          "label": "unusedAggregator",
+          "slot": "2",
+          "offset": 0,
+          "type": "t_address"
+        },
+        {
+          "label": "acl",
+          "slot": "3",
+          "offset": 0,
+          "type": "t_contract(ACL)"
+        },
+        {
+          "label": "verifierSigner",
+          "slot": "4",
+          "offset": 0,
+          "type": "t_address"
+        },
+        {
+          "label": "version",
+          "slot": "4",
+          "offset": 20,
+          "type": "t_uint8"
+        },
+        {
+          "label": "plaintextsStorage",
+          "slot": "5",
+          "offset": 0,
+          "type": "t_contract(PlaintextsStorage)"
+        },
+        {
+          "label": "aggregators",
+          "slot": "6",
+          "offset": 0,
+          "type": "t_mapping(t_address,t_bool)"
+        },
+        {
+          "label": "isEnabled",
+          "slot": "7",
+          "offset": 0,
+          "type": "t_bool"
+        },
+        {
+          "label": "decryptResultSigner",
+          "slot": "7",
+          "offset": 1,
+          "type": "t_address"
+        }
+      ],
+      "types": {
+        "t_address": {
+          "label": "address",
+          "numberOfBytes": "20"
+        },
+        "t_bool": {
+          "label": "bool",
+          "numberOfBytes": "1"
+        },
+        "t_contract(ACL)": {
+          "label": "contract ACL",
+          "numberOfBytes": "20"
+        },
+        "t_contract(PlaintextsStorage)": {
+          "label": "contract PlaintextsStorage",
+          "numberOfBytes": "20"
+        },
+        "t_int32": {
+          "label": "int32",
+          "numberOfBytes": "4"
+        },
+        "t_mapping(t_address,t_bool)": {
+          "label": "mapping(address => bool)",
+          "numberOfBytes": "32"
+        },
+        "t_uint256": {
+          "label": "uint256",
+          "numberOfBytes": "32"
+        },
+        "t_uint8": {
+          "label": "uint8",
+          "numberOfBytes": "1"
+        },
+        "t_uint64": {
+          "label": "uint64",
+          "numberOfBytes": "0"
+        }
+      },
+      "namespaces": {
+        "erc7201:openzeppelin.storage.Ownable2Step": [
+          {
+            "label": "_pendingOwner",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_address"
+          }
+        ],
+        "erc7201:openzeppelin.storage.Ownable": [
+          {
+            "label": "_owner",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_address"
+          }
+        ],
+        "erc7201:openzeppelin.storage.Initializable": [
+          {
+            "label": "_initialized",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_uint64"
+          },
+          {
+            "label": "_initializing",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_bool"
+          }
+        ]
+      }
+    },
+    "ACL": {
+      "storage": [],
+      "types": {
+        "t_mapping(t_uint256,t_bool)": {
+          "label": "mapping(uint256 => bool)",
+          "numberOfBytes": "0"
+        },
+        "t_uint256": {
+          "label": "uint256",
+          "numberOfBytes": "0"
+        },
+        "t_bool": {
+          "label": "bool",
+          "numberOfBytes": "0"
+        },
+        "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+          "label": "mapping(uint256 => mapping(address => bool))",
+          "numberOfBytes": "0"
+        },
+        "t_mapping(t_address,t_bool)": {
+          "label": "mapping(address => bool)",
+          "numberOfBytes": "0"
+        },
+        "t_address": {
+          "label": "address",
+          "numberOfBytes": "0"
+        },
+        "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_bool)))": {
+          "label": "mapping(address => mapping(address => mapping(address => bool)))",
+          "numberOfBytes": "0"
+        },
+        "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+          "label": "mapping(address => mapping(address => bool))",
+          "numberOfBytes": "0"
+        },
+        "t_bytes32": {
+          "label": "bytes32",
+          "numberOfBytes": "0"
+        },
+        "t_string_storage": {
+          "label": "string",
+          "numberOfBytes": "0"
+        },
+        "t_uint64": {
+          "label": "uint64",
+          "numberOfBytes": "0"
+        }
+      },
+      "namespaces": {
+        "erc7201:cofhe.storage.ACL": [
+          {
+            "label": "globalHandles",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_mapping(t_uint256,t_bool)"
+          },
+          {
+            "label": "persistedAllowedPairs",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
+          },
+          {
+            "label": "allowedForDecryption",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_mapping(t_uint256,t_bool)"
+          },
+          {
+            "label": "delegates",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_bool)))"
+          }
+        ],
+        "erc7201:openzeppelin.storage.EIP712": [
+          {
+            "label": "_hashedName",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_bytes32"
+          },
+          {
+            "label": "_hashedVersion",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_bytes32"
+          },
+          {
+            "label": "_name",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_string_storage"
+          },
+          {
+            "label": "_version",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_string_storage"
+          }
+        ],
+        "erc7201:openzeppelin.storage.Ownable2Step": [
+          {
+            "label": "_pendingOwner",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_address"
+          }
+        ],
+        "erc7201:openzeppelin.storage.Ownable": [
+          {
+            "label": "_owner",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_address"
+          }
+        ],
+        "erc7201:openzeppelin.storage.Initializable": [
+          {
+            "label": "_initialized",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_uint64"
+          },
+          {
+            "label": "_initializing",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_bool"
+          }
+        ]
+      }
+    },
+    "PlaintextsStorage": {
+      "storage": [
+        {
+          "label": "plaintextResults",
+          "slot": "0",
+          "offset": 0,
+          "type": "t_mapping(t_uint256,t_struct(PlaintextResult)_storage)"
+        }
+      ],
+      "types": {
+        "t_bool": {
+          "label": "bool",
+          "numberOfBytes": "1"
+        },
+        "t_mapping(t_uint256,t_struct(PlaintextResult)_storage)": {
+          "label": "mapping(uint256 => struct PlaintextsStorage.PlaintextResult)",
+          "numberOfBytes": "32"
+        },
+        "t_struct(PlaintextResult)_storage": {
+          "label": "struct PlaintextsStorage.PlaintextResult",
+          "numberOfBytes": "64",
+          "members": [
+            {
+              "label": "existenceIndicator",
+              "type": "t_bool",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "label": "result",
+              "type": "t_uint256",
+              "offset": 0,
+              "slot": "1"
+            }
+          ]
+        },
+        "t_uint256": {
+          "label": "uint256",
+          "numberOfBytes": "32"
+        },
+        "t_address": {
+          "label": "address",
+          "numberOfBytes": "0"
+        },
+        "t_uint64": {
+          "label": "uint64",
+          "numberOfBytes": "0"
+        }
+      },
+      "namespaces": {
+        "erc7201:openzeppelin.storage.Ownable": [
+          {
+            "label": "_owner",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_address"
+          }
+        ],
+        "erc7201:openzeppelin.storage.Initializable": [
+          {
+            "label": "_initialized",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_uint64"
+          },
+          {
+            "label": "_initializing",
+            "slot": "0",
+            "offset": 0,
+            "type": "t_bool"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/internal/host-chain/storage-layout-snapshot.json
+++ b/contracts/internal/host-chain/storage-layout-snapshot.json
@@ -2,78 +2,103 @@
   "version": 1,
   "contracts": {
     "TaskManager": {
+      "solcVersion": "0.8.25",
       "storage": [
         {
           "label": "initialized",
-          "slot": "0",
           "offset": 0,
-          "type": "t_bool"
+          "slot": "0",
+          "type": "t_bool",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:155"
         },
         {
           "label": "securityZoneMax",
-          "slot": "0",
           "offset": 1,
-          "type": "t_int32"
+          "slot": "0",
+          "type": "t_int32",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:215"
         },
         {
           "label": "securityZoneMin",
-          "slot": "0",
           "offset": 5,
-          "type": "t_int32"
+          "slot": "0",
+          "type": "t_int32",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:216"
         },
         {
           "label": "randomCounter",
-          "slot": "1",
           "offset": 0,
-          "type": "t_uint256"
+          "slot": "1",
+          "type": "t_uint256",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:219"
         },
         {
           "label": "unusedAggregator",
-          "slot": "2",
           "offset": 0,
-          "type": "t_address"
+          "slot": "2",
+          "type": "t_address",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:221"
         },
         {
           "label": "acl",
-          "slot": "3",
           "offset": 0,
-          "type": "t_contract(ACL)"
+          "slot": "3",
+          "type": "t_contract(ACL)25384",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:224"
         },
         {
           "label": "verifierSigner",
-          "slot": "4",
           "offset": 0,
-          "type": "t_address"
+          "slot": "4",
+          "type": "t_address",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:226"
         },
         {
           "label": "version",
-          "slot": "4",
           "offset": 20,
-          "type": "t_uint8"
+          "slot": "4",
+          "type": "t_uint8",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:228"
         },
         {
           "label": "plaintextsStorage",
-          "slot": "5",
           "offset": 0,
-          "type": "t_contract(PlaintextsStorage)"
+          "slot": "5",
+          "type": "t_contract(PlaintextsStorage)25814",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:231"
         },
         {
           "label": "aggregators",
-          "slot": "6",
           "offset": 0,
-          "type": "t_mapping(t_address,t_bool)"
+          "slot": "6",
+          "type": "t_mapping(t_address,t_bool)",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:233"
         },
         {
           "label": "isEnabled",
-          "slot": "7",
           "offset": 0,
-          "type": "t_bool"
+          "slot": "7",
+          "type": "t_bool",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:237"
         },
         {
           "label": "decryptResultSigner",
-          "slot": "7",
           "offset": 1,
-          "type": "t_address"
+          "slot": "7",
+          "type": "t_address",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:241"
         }
       ],
       "types": {
@@ -85,11 +110,11 @@
           "label": "bool",
           "numberOfBytes": "1"
         },
-        "t_contract(ACL)": {
+        "t_contract(ACL)25384": {
           "label": "contract ACL",
           "numberOfBytes": "20"
         },
-        "t_contract(PlaintextsStorage)": {
+        "t_contract(PlaintextsStorage)25814": {
           "label": "contract PlaintextsStorage",
           "numberOfBytes": "20"
         },
@@ -110,183 +135,175 @@
           "numberOfBytes": "1"
         },
         "t_uint64": {
-          "label": "uint64",
-          "numberOfBytes": "0"
+          "label": "uint64"
         }
       },
       "namespaces": {
         "erc7201:openzeppelin.storage.Ownable2Step": [
           {
+            "contract": "Ownable2StepUpgradeable",
             "label": "_pendingOwner",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_address"
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol:29"
           }
         ],
         "erc7201:openzeppelin.storage.Ownable": [
           {
+            "contract": "OwnableUpgradeable",
             "label": "_owner",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_address"
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
           }
         ],
         "erc7201:openzeppelin.storage.Initializable": [
           {
+            "contract": "Initializable",
             "label": "_initialized",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_uint64"
+            "type": "t_uint64",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
           },
           {
+            "contract": "Initializable",
             "label": "_initializing",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_bool"
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
           }
         ]
       }
     },
     "ACL": {
+      "solcVersion": "0.8.25",
       "storage": [],
       "types": {
         "t_mapping(t_uint256,t_bool)": {
-          "label": "mapping(uint256 => bool)",
-          "numberOfBytes": "0"
+          "label": "mapping(uint256 => bool)"
         },
         "t_uint256": {
-          "label": "uint256",
-          "numberOfBytes": "0"
+          "label": "uint256"
         },
         "t_bool": {
-          "label": "bool",
-          "numberOfBytes": "0"
+          "label": "bool"
         },
         "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
-          "label": "mapping(uint256 => mapping(address => bool))",
-          "numberOfBytes": "0"
+          "label": "mapping(uint256 => mapping(address => bool))"
         },
         "t_mapping(t_address,t_bool)": {
-          "label": "mapping(address => bool)",
-          "numberOfBytes": "0"
+          "label": "mapping(address => bool)"
         },
         "t_address": {
-          "label": "address",
-          "numberOfBytes": "0"
+          "label": "address"
         },
         "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_bool)))": {
-          "label": "mapping(address => mapping(address => mapping(address => bool)))",
-          "numberOfBytes": "0"
+          "label": "mapping(address => mapping(address => mapping(address => bool)))"
         },
         "t_mapping(t_address,t_mapping(t_address,t_bool))": {
-          "label": "mapping(address => mapping(address => bool))",
-          "numberOfBytes": "0"
+          "label": "mapping(address => mapping(address => bool))"
         },
         "t_bytes32": {
-          "label": "bytes32",
-          "numberOfBytes": "0"
+          "label": "bytes32"
         },
         "t_string_storage": {
-          "label": "string",
-          "numberOfBytes": "0"
+          "label": "string"
         },
         "t_uint64": {
-          "label": "uint64",
-          "numberOfBytes": "0"
+          "label": "uint64"
         }
       },
       "namespaces": {
         "erc7201:cofhe.storage.ACL": [
           {
+            "contract": "ACL",
             "label": "globalHandles",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_mapping(t_uint256,t_bool)"
+            "type": "t_mapping(t_uint256,t_bool)",
+            "src": "contracts/ACL.sol:44"
           },
           {
+            "contract": "ACL",
             "label": "persistedAllowedPairs",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "src": "contracts/ACL.sol:45"
           },
           {
+            "contract": "ACL",
             "label": "allowedForDecryption",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_mapping(t_uint256,t_bool)"
+            "type": "t_mapping(t_uint256,t_bool)",
+            "src": "contracts/ACL.sol:46"
           },
           {
+            "contract": "ACL",
             "label": "delegates",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_bool)))"
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_bool)))",
+            "src": "contracts/ACL.sol:47"
           }
         ],
         "erc7201:openzeppelin.storage.EIP712": [
           {
+            "contract": "EIP712Upgradeable",
             "label": "_hashedName",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_bytes32"
+            "type": "t_bytes32",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:39"
           },
           {
+            "contract": "EIP712Upgradeable",
             "label": "_hashedVersion",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_bytes32"
+            "type": "t_bytes32",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:41"
           },
           {
+            "contract": "EIP712Upgradeable",
             "label": "_name",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_string_storage"
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43"
           },
           {
+            "contract": "EIP712Upgradeable",
             "label": "_version",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_string_storage"
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:44"
           }
         ],
         "erc7201:openzeppelin.storage.Ownable2Step": [
           {
+            "contract": "Ownable2StepUpgradeable",
             "label": "_pendingOwner",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_address"
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol:29"
           }
         ],
         "erc7201:openzeppelin.storage.Ownable": [
           {
+            "contract": "OwnableUpgradeable",
             "label": "_owner",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_address"
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
           }
         ],
         "erc7201:openzeppelin.storage.Initializable": [
           {
+            "contract": "Initializable",
             "label": "_initialized",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_uint64"
+            "type": "t_uint64",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
           },
           {
+            "contract": "Initializable",
             "label": "_initializing",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_bool"
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
           }
         ]
       }
     },
     "PlaintextsStorage": {
+      "solcVersion": "0.8.25",
       "storage": [
         {
           "label": "plaintextResults",
-          "slot": "0",
           "offset": 0,
-          "type": "t_mapping(t_uint256,t_struct(PlaintextResult)_storage)"
+          "slot": "0",
+          "type": "t_mapping(t_uint256,t_struct(PlaintextResult)25715_storage)",
+          "contract": "PlaintextsStorage",
+          "src": "contracts/PlaintextsStorage.sol:13"
         }
       ],
       "types": {
@@ -294,13 +311,12 @@
           "label": "bool",
           "numberOfBytes": "1"
         },
-        "t_mapping(t_uint256,t_struct(PlaintextResult)_storage)": {
+        "t_mapping(t_uint256,t_struct(PlaintextResult)25715_storage)": {
           "label": "mapping(uint256 => struct PlaintextsStorage.PlaintextResult)",
           "numberOfBytes": "32"
         },
-        "t_struct(PlaintextResult)_storage": {
+        "t_struct(PlaintextResult)25715_storage": {
           "label": "struct PlaintextsStorage.PlaintextResult",
-          "numberOfBytes": "64",
           "members": [
             {
               "label": "existenceIndicator",
@@ -314,42 +330,41 @@
               "offset": 0,
               "slot": "1"
             }
-          ]
+          ],
+          "numberOfBytes": "64"
         },
         "t_uint256": {
           "label": "uint256",
           "numberOfBytes": "32"
         },
         "t_address": {
-          "label": "address",
-          "numberOfBytes": "0"
+          "label": "address"
         },
         "t_uint64": {
-          "label": "uint64",
-          "numberOfBytes": "0"
+          "label": "uint64"
         }
       },
       "namespaces": {
         "erc7201:openzeppelin.storage.Ownable": [
           {
+            "contract": "OwnableUpgradeable",
             "label": "_owner",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_address"
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
           }
         ],
         "erc7201:openzeppelin.storage.Initializable": [
           {
+            "contract": "Initializable",
             "label": "_initialized",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_uint64"
+            "type": "t_uint64",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
           },
           {
+            "contract": "Initializable",
             "label": "_initializing",
-            "slot": "0",
-            "offset": 0,
-            "type": "t_bool"
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
           }
         ]
       }

--- a/contracts/internal/host-chain/tasks/checkContractSize.ts
+++ b/contracts/internal/host-chain/tasks/checkContractSize.ts
@@ -1,0 +1,59 @@
+import { task } from "hardhat/config";
+import chalk from "chalk";
+
+const EVM_SIZE_LIMIT = 24_576; // 24KB
+const WARN_THRESHOLD = 22_528; // 22KB
+
+const TRACKED_CONTRACTS = [
+  "TaskManager",
+  "ACL",
+  "PlaintextsStorage",
+  "ERC1967Proxy",
+];
+
+task(
+  "task:check-contract-size",
+  "Check that contract bytecode stays within the 24KB EVM limit"
+).setAction(async function (_taskArguments, hre) {
+  await hre.run("compile");
+
+  let failed = false;
+
+  for (const name of TRACKED_CONTRACTS) {
+    const artifact = await hre.artifacts.readArtifact(name);
+    // deployedBytecode is a hex string starting with "0x"
+    const bytecodeSize = (artifact.deployedBytecode.length - 2) / 2;
+
+    const pct = ((bytecodeSize / EVM_SIZE_LIMIT) * 100).toFixed(1);
+
+    if (bytecodeSize > EVM_SIZE_LIMIT) {
+      console.log(
+        chalk.red(
+          `FAIL: ${name} — ${bytecodeSize} bytes (${pct}% of limit, exceeds 24KB by ${bytecodeSize - EVM_SIZE_LIMIT} bytes)`
+        )
+      );
+      failed = true;
+    } else if (bytecodeSize > WARN_THRESHOLD) {
+      console.log(
+        chalk.yellow(
+          `WARN: ${name} — ${bytecodeSize} bytes (${pct}% of limit)`
+        )
+      );
+    } else {
+      console.log(
+        chalk.green(`OK:   ${name} — ${bytecodeSize} bytes (${pct}% of limit)`)
+      );
+    }
+  }
+
+  if (failed) {
+    console.log(
+      chalk.red(
+        "\nOne or more contracts exceed the 24KB EVM bytecode size limit."
+      )
+    );
+    process.exit(1);
+  } else {
+    console.log(chalk.green("\nAll contracts are within the 24KB size limit."));
+  }
+});

--- a/contracts/internal/host-chain/tasks/index.ts
+++ b/contracts/internal/host-chain/tasks/index.ts
@@ -1,3 +1,5 @@
 export * from "./deployContract";
 export * from "./upgradeTM";
 export * from "./deployDeterministicTM";
+export * from "./storageLayout";
+export * from "./checkContractSize";

--- a/contracts/internal/host-chain/tasks/storageLayout.ts
+++ b/contracts/internal/host-chain/tasks/storageLayout.ts
@@ -9,6 +9,8 @@ import {
   concatRunData,
   getContractVersion,
   getStorageLayout,
+  getStorageUpgradeReport,
+  withValidationDefaults,
   type ValidationDataCurrent,
   type StorageLayout,
 } from "@openzeppelin/upgrades-core";
@@ -17,80 +19,14 @@ const TRACKED_CONTRACTS = ["TaskManager", "ACL", "PlaintextsStorage"];
 
 const SNAPSHOT_FILE = "storage-layout-snapshot.json";
 
-interface NormalizedLayout {
-  storage: Array<{
-    label: string;
-    slot: string;
-    offset: number;
-    type: string;
-  }>;
-  types: Record<string, { label: string; numberOfBytes: string; members?: unknown[] }>;
-  namespaces: Record<
-    string,
-    Array<{ label: string; slot: string; offset: number; type: string }>
-  >;
-}
-
 interface Snapshot {
   version: number;
-  contracts: Record<string, NormalizedLayout>;
-}
-
-/**
- * Strip AST node IDs from type identifiers.
- * e.g. "t_contract(ACL)8522" -> "t_contract(ACL)"
- *      "t_struct(TaskManagerStorage)12345_storage" -> "t_struct(TaskManagerStorage)_storage"
- */
-function stripTypeIds(typeId: string): string {
-  return typeId.replace(/\)\d+/g, ")");
-}
-
-function normalizeLayout(layout: StorageLayout): NormalizedLayout {
-  const storage = layout.storage.map((item) => ({
-    label: item.label,
-    slot: item.slot ?? "0",
-    offset: item.offset ?? 0,
-    type: stripTypeIds(item.type),
-  }));
-
-  const types: NormalizedLayout["types"] = {};
-  for (const [key, value] of Object.entries(layout.types)) {
-    const normalizedKey = stripTypeIds(key);
-    types[normalizedKey] = {
-      label: value.label,
-      numberOfBytes: value.numberOfBytes ?? "0",
-    };
-    if (value.members && Array.isArray(value.members)) {
-      types[normalizedKey].members = value.members.map((m: any) => {
-        if (typeof m === "string") return m;
-        return {
-          label: m.label,
-          type: stripTypeIds(m.type),
-          ...(m.offset !== undefined && { offset: m.offset }),
-          ...(m.slot !== undefined && { slot: m.slot }),
-        };
-      });
-    }
-  }
-
-  const namespaces: NormalizedLayout["namespaces"] = {};
-  if (layout.namespaces) {
-    for (const [ns, items] of Object.entries(layout.namespaces)) {
-      namespaces[ns] = items.map((item) => ({
-        label: item.label,
-        slot: item.slot ?? "0",
-        offset: item.offset ?? 0,
-        type: stripTypeIds(item.type),
-      }));
-    }
-  }
-
-  return { storage, types, namespaces };
+  contracts: Record<string, StorageLayout>;
 }
 
 async function extractLayouts(
   hre: HardhatRuntimeEnvironment
-): Promise<Record<string, NormalizedLayout>> {
+): Promise<Record<string, StorageLayout>> {
   const buildInfoDir = path.join(hre.config.paths.artifacts, "build-info");
   if (!fs.existsSync(buildInfoDir)) {
     throw new Error(
@@ -126,10 +62,9 @@ async function extractLayouts(
     throw new Error("No validation data could be extracted.");
   }
 
-  const layouts: Record<string, NormalizedLayout> = {};
+  const layouts: Record<string, StorageLayout> = {};
 
   for (const contractName of TRACKED_CONTRACTS) {
-    // Search all log entries for the contract
     let found = false;
     for (const runData of validationData.log) {
       const fqn = Object.keys(runData).find((key) =>
@@ -137,8 +72,7 @@ async function extractLayouts(
       );
       if (fqn) {
         const version = getContractVersion(runData, fqn);
-        const layout = getStorageLayout(validationData, version);
-        layouts[contractName] = normalizeLayout(layout);
+        layouts[contractName] = getStorageLayout(validationData, version);
         found = true;
         break;
       }
@@ -155,7 +89,7 @@ async function extractLayouts(
 }
 
 task("task:storage-layout", "Extract and validate storage layout snapshot")
-  .addFlag("check", "Check current layout against committed snapshot")
+  .addFlag("check", "Check current layout is upgrade-compatible with snapshot")
   .setAction(async function (taskArguments, hre) {
     await hre.run("compile");
 
@@ -175,53 +109,57 @@ task("task:storage-layout", "Extract and validate storage layout snapshot")
       const committed: Snapshot = JSON.parse(
         fs.readFileSync(snapshotPath, "utf8")
       );
-      const current: Snapshot = { version: 1, contracts: layouts };
 
-      const committedStr = JSON.stringify(committed, null, 2);
-      const currentStr = JSON.stringify(current, null, 2);
+      const opts = withValidationDefaults({});
+      let failed = false;
 
-      if (committedStr === currentStr) {
-        console.log(
-          chalk.green("Storage layout matches committed snapshot.")
-        );
-      } else {
-        console.log(
-          chalk.red("Storage layout has changed from committed snapshot!")
-        );
-        console.log(
-          chalk.yellow(
-            "If this change is intentional, run 'pnpm storage-layout:generate' and commit the updated snapshot."
-          )
-        );
+      for (const name of TRACKED_CONTRACTS) {
+        const original = committed.contracts[name];
+        const updated = layouts[name];
 
-        // Show which contracts changed
-        for (const name of TRACKED_CONTRACTS) {
-          const committedLayout = JSON.stringify(
-            committed.contracts[name],
-            null,
-            2
+        if (!original) {
+          console.log(
+            chalk.yellow(
+              `WARN: ${name} not found in snapshot — skipping compatibility check.`
+            )
           );
-          const currentLayout = JSON.stringify(
-            current.contracts[name],
-            null,
-            2
-          );
-          if (committedLayout !== currentLayout) {
-            console.log(chalk.red(`  - ${name} storage layout changed`));
-          }
+          continue;
         }
 
+        const report = getStorageUpgradeReport(original, updated, opts);
+
+        if (report.ok) {
+          console.log(
+            chalk.green(`OK: ${name} — storage layout is upgrade-compatible.`)
+          );
+        } else {
+          console.log(
+            chalk.red(`FAIL: ${name} — storage layout is NOT upgrade-compatible:`)
+          );
+          console.log(report.explain(true));
+          failed = true;
+        }
+      }
+
+      if (failed) {
+        console.log(
+          chalk.red(
+            "\nStorage layout incompatibility detected. This would break UUPS upgrades."
+          )
+        );
         process.exit(1);
       }
     } else {
       const snapshot: Snapshot = { version: 1, contracts: layouts };
       fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2) + "\n");
-      console.log(chalk.green(`Storage layout snapshot written to ${SNAPSHOT_FILE}`));
+      console.log(
+        chalk.green(`Storage layout snapshot written to ${SNAPSHOT_FILE}`)
+      );
 
       for (const name of TRACKED_CONTRACTS) {
         const layout = layouts[name];
         const slotCount = layout.storage.length;
-        const nsCount = Object.keys(layout.namespaces).length;
+        const nsCount = Object.keys(layout.namespaces ?? {}).length;
         console.log(
           chalk.cyan(
             `  ${name}: ${slotCount} storage slots, ${nsCount} namespaces`

--- a/contracts/internal/host-chain/tasks/storageLayout.ts
+++ b/contracts/internal/host-chain/tasks/storageLayout.ts
@@ -1,0 +1,232 @@
+import { task } from "hardhat/config";
+import type { HardhatRuntimeEnvironment } from "hardhat/types";
+import * as fs from "fs";
+import * as path from "path";
+import chalk from "chalk";
+import {
+  validate,
+  solcInputOutputDecoder,
+  concatRunData,
+  getContractVersion,
+  getStorageLayout,
+  type ValidationDataCurrent,
+  type StorageLayout,
+} from "@openzeppelin/upgrades-core";
+
+const TRACKED_CONTRACTS = ["TaskManager", "ACL", "PlaintextsStorage"];
+
+const SNAPSHOT_FILE = "storage-layout-snapshot.json";
+
+interface NormalizedLayout {
+  storage: Array<{
+    label: string;
+    slot: string;
+    offset: number;
+    type: string;
+  }>;
+  types: Record<string, { label: string; numberOfBytes: string; members?: unknown[] }>;
+  namespaces: Record<
+    string,
+    Array<{ label: string; slot: string; offset: number; type: string }>
+  >;
+}
+
+interface Snapshot {
+  version: number;
+  contracts: Record<string, NormalizedLayout>;
+}
+
+/**
+ * Strip AST node IDs from type identifiers.
+ * e.g. "t_contract(ACL)8522" -> "t_contract(ACL)"
+ *      "t_struct(TaskManagerStorage)12345_storage" -> "t_struct(TaskManagerStorage)_storage"
+ */
+function stripTypeIds(typeId: string): string {
+  return typeId.replace(/\)\d+/g, ")");
+}
+
+function normalizeLayout(layout: StorageLayout): NormalizedLayout {
+  const storage = layout.storage.map((item) => ({
+    label: item.label,
+    slot: item.slot ?? "0",
+    offset: item.offset ?? 0,
+    type: stripTypeIds(item.type),
+  }));
+
+  const types: NormalizedLayout["types"] = {};
+  for (const [key, value] of Object.entries(layout.types)) {
+    const normalizedKey = stripTypeIds(key);
+    types[normalizedKey] = {
+      label: value.label,
+      numberOfBytes: value.numberOfBytes ?? "0",
+    };
+    if (value.members && Array.isArray(value.members)) {
+      types[normalizedKey].members = value.members.map((m: any) => {
+        if (typeof m === "string") return m;
+        return {
+          label: m.label,
+          type: stripTypeIds(m.type),
+          ...(m.offset !== undefined && { offset: m.offset }),
+          ...(m.slot !== undefined && { slot: m.slot }),
+        };
+      });
+    }
+  }
+
+  const namespaces: NormalizedLayout["namespaces"] = {};
+  if (layout.namespaces) {
+    for (const [ns, items] of Object.entries(layout.namespaces)) {
+      namespaces[ns] = items.map((item) => ({
+        label: item.label,
+        slot: item.slot ?? "0",
+        offset: item.offset ?? 0,
+        type: stripTypeIds(item.type),
+      }));
+    }
+  }
+
+  return { storage, types, namespaces };
+}
+
+async function extractLayouts(
+  hre: HardhatRuntimeEnvironment
+): Promise<Record<string, NormalizedLayout>> {
+  const buildInfoDir = path.join(hre.config.paths.artifacts, "build-info");
+  if (!fs.existsSync(buildInfoDir)) {
+    throw new Error(
+      "No build-info directory found. Run `pnpm compile` first."
+    );
+  }
+
+  const buildInfoFiles = fs
+    .readdirSync(buildInfoDir)
+    .filter((f) => f.endsWith(".json"));
+
+  if (buildInfoFiles.length === 0) {
+    throw new Error("No build-info files found. Run `pnpm compile` first.");
+  }
+
+  let validationData: ValidationDataCurrent | undefined;
+
+  for (const file of buildInfoFiles) {
+    const buildInfo = JSON.parse(
+      fs.readFileSync(path.join(buildInfoDir, file), "utf8")
+    );
+    const decodeSrc = solcInputOutputDecoder(buildInfo.input, buildInfo.output);
+    const runData = validate(
+      buildInfo.output,
+      decodeSrc,
+      buildInfo.solcVersion,
+      buildInfo.input
+    );
+    validationData = concatRunData(runData, validationData);
+  }
+
+  if (!validationData) {
+    throw new Error("No validation data could be extracted.");
+  }
+
+  const layouts: Record<string, NormalizedLayout> = {};
+
+  for (const contractName of TRACKED_CONTRACTS) {
+    // Search all log entries for the contract
+    let found = false;
+    for (const runData of validationData.log) {
+      const fqn = Object.keys(runData).find((key) =>
+        key.endsWith(`:${contractName}`)
+      );
+      if (fqn) {
+        const version = getContractVersion(runData, fqn);
+        const layout = getStorageLayout(validationData, version);
+        layouts[contractName] = normalizeLayout(layout);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      throw new Error(
+        `Contract ${contractName} not found in compiled artifacts.`
+      );
+    }
+  }
+
+  return layouts;
+}
+
+task("task:storage-layout", "Extract and validate storage layout snapshot")
+  .addFlag("check", "Check current layout against committed snapshot")
+  .setAction(async function (taskArguments, hre) {
+    await hre.run("compile");
+
+    const layouts = await extractLayouts(hre);
+    const snapshotPath = path.join(hre.config.paths.root, SNAPSHOT_FILE);
+
+    if (taskArguments.check) {
+      if (!fs.existsSync(snapshotPath)) {
+        console.log(
+          chalk.red(
+            `No snapshot file found at ${SNAPSHOT_FILE}. Run 'pnpm storage-layout:generate' first.`
+          )
+        );
+        process.exit(1);
+      }
+
+      const committed: Snapshot = JSON.parse(
+        fs.readFileSync(snapshotPath, "utf8")
+      );
+      const current: Snapshot = { version: 1, contracts: layouts };
+
+      const committedStr = JSON.stringify(committed, null, 2);
+      const currentStr = JSON.stringify(current, null, 2);
+
+      if (committedStr === currentStr) {
+        console.log(
+          chalk.green("Storage layout matches committed snapshot.")
+        );
+      } else {
+        console.log(
+          chalk.red("Storage layout has changed from committed snapshot!")
+        );
+        console.log(
+          chalk.yellow(
+            "If this change is intentional, run 'pnpm storage-layout:generate' and commit the updated snapshot."
+          )
+        );
+
+        // Show which contracts changed
+        for (const name of TRACKED_CONTRACTS) {
+          const committedLayout = JSON.stringify(
+            committed.contracts[name],
+            null,
+            2
+          );
+          const currentLayout = JSON.stringify(
+            current.contracts[name],
+            null,
+            2
+          );
+          if (committedLayout !== currentLayout) {
+            console.log(chalk.red(`  - ${name} storage layout changed`));
+          }
+        }
+
+        process.exit(1);
+      }
+    } else {
+      const snapshot: Snapshot = { version: 1, contracts: layouts };
+      fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2) + "\n");
+      console.log(chalk.green(`Storage layout snapshot written to ${SNAPSHOT_FILE}`));
+
+      for (const name of TRACKED_CONTRACTS) {
+        const layout = layouts[name];
+        const slotCount = layout.storage.length;
+        const nsCount = Object.keys(layout.namespaces).length;
+        console.log(
+          chalk.cyan(
+            `  ${name}: ${slotCount} storage slots, ${nsCount} namespaces`
+          )
+        );
+      }
+    }
+  });


### PR DESCRIPTION
## Summary

Adds a comprehensive CI pipeline (`checks.yml`) with 5 parallel jobs to catch issues before merge. The existing `test.yml` is untouched.

- **Storage layout snapshot validation** — prevents accidental storage slot changes that would brick UUPS upgrades for TaskManager, ACL, and PlaintextsStorage
- **Contract size enforcement** — enforces the 24KB EVM bytecode limit (currently masked by Hardhat's `allowUnlimitedContractSize: true`)
- **Solhint linting** — static lint with project-specific rule overrides matching existing code patterns
- **Slither static analysis** — catches medium+ severity findings (informational/optimization excluded)
- **Gas reporting** — runs tests with `hardhat-gas-reporter` and uploads the report as a CI artifact

## New Files

| File | Purpose |
|------|---------|
| `.github/workflows/checks.yml` | CI workflow with 5 parallel jobs |
| `tasks/storageLayout.ts` | Hardhat task: extract & validate storage layout via `@openzeppelin/upgrades-core` |
| `tasks/checkContractSize.ts` | Hardhat task: enforce 24KB bytecode limit, warn at 22KB |
| `.solhint.json` | Solhint config (extends `solhint:recommended`) |
| `.solhintignore` | Excludes `node_modules/`, `contracts/tests/`, `contracts/detereministic-tm/` |
| `slither.config.json` | Slither config (filter paths, exclude informational, fail on medium+) |
| `storage-layout-snapshot.json` | Initial storage layout snapshot |

## Modified Files

| File | Change |
|------|--------|
| `tasks/index.ts` | Exports new tasks |
| `package.json` | Added `solhint` devDep + scripts: `storage-layout:generate`, `storage-layout:check`, `check:size`, `lint:sol` |
| `hardhat.config.ts` | Added `gasReporter` config (gated by `REPORT_GAS` env var) |

## New Scripts

```bash
pnpm storage-layout:generate  # Generate/update storage-layout-snapshot.json
pnpm storage-layout:check     # Validate current layout matches snapshot (CI)
pnpm check:size                # Check contract sizes against 24KB limit
pnpm lint:sol                  # Run Solhint
```

## Local Verification

All checks pass locally:

```
pnpm compile             ✅
pnpm test                ✅ 32/32 passing
pnpm lint:sol            ✅ (1 warning: unused Strings import in TaskManager.sol)
pnpm storage-layout:check ✅
pnpm check:size          ✅ TaskManager 66.8%, ACL 37.2%, PlaintextsStorage 9.2%, ERC1967Proxy 0.4%
```

## Current Contract Sizes

| Contract | Size | % of 24KB Limit |
|----------|------|-----------------|
| TaskManager | 16,428 bytes | 66.8% |
| ACL | 9,130 bytes | 37.2% |
| PlaintextsStorage | 2,258 bytes | 9.2% |
| ERC1967Proxy | 100 bytes | 0.4% |

## Notes

- Solhint flags an unused `Strings` import in `TaskManager.sol` as a warning (not error). Consider removing it in a follow-up.
- Slither job uses `crytic/slither-action@v0.4.0` with solc 0.8.25 pinned.
- Gas report is uploaded as a CI artifact with 30-day retention.

## Test plan

- [x] Verify `checks.yml` CI jobs all pass on this PR
- [x] Confirm existing `test.yml` is unaffected
- [x] Modify a storage slot locally and verify `storage-layout:check` fails
- [x] Verify Slither doesn't produce false-positive medium+ findings