### PR TITLE
[FEAT] Add batch verify/publish typed overloads to TaskManager

### DIFF
--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -143,12 +143,16 @@ library Impl {
         ITaskManager(TASK_MANAGER_ADDRESS).publishDecryptResult(uint256(ctHash), result, signature);
     }
 
+    function publishDecryptResultBatch(uint256[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal {
+        ITaskManager(TASK_MANAGER_ADDRESS).publishDecryptResultBatch(ctHashes, results, signatures);
+    }
+
     function publishDecryptResultBatch(bytes32[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal {
         uint256[] memory ctHashesUint = new uint256[](ctHashes.length);
         for (uint256 i = 0; i < ctHashes.length; i++) {
             ctHashesUint[i] = uint256(ctHashes[i]);
         }
-        ITaskManager(TASK_MANAGER_ADDRESS).publishDecryptResultBatch(ctHashesUint, results, signatures);
+        publishDecryptResultBatch(ctHashesUint, results, signatures);
     }
 
     function verifyDecryptResult(bytes32 ctHash, uint256 result, bytes memory signature) internal view returns (bool) {
@@ -157,6 +161,30 @@ library Impl {
 
     function verifyDecryptResultSafe(bytes32 ctHash, uint256 result, bytes memory signature) internal view returns (bool) {
         return ITaskManager(TASK_MANAGER_ADDRESS).verifyDecryptResultSafe(uint256(ctHash), result, signature);
+    }
+
+    function verifyDecryptResultBatch(uint256[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        return ITaskManager(TASK_MANAGER_ADDRESS).verifyDecryptResultBatch(ctHashes, results, signatures);
+    }
+
+    function verifyDecryptResultBatch(bytes32[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashesUint = new uint256[](ctHashes.length);
+        for (uint256 i = 0; i < ctHashes.length; i++) {
+            ctHashesUint[i] = uint256(ctHashes[i]);
+        }
+        return verifyDecryptResultBatch(ctHashesUint, results, signatures);
+    }
+
+    function verifyDecryptResultBatchSafe(uint256[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        return ITaskManager(TASK_MANAGER_ADDRESS).verifyDecryptResultBatchSafe(ctHashes, results, signatures);
+    }
+
+    function verifyDecryptResultBatchSafe(bytes32[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashesUint = new uint256[](ctHashes.length);
+        for (uint256 i = 0; i < ctHashes.length; i++) {
+            ctHashesUint[i] = uint256(ctHashes[i]);
+        }
+        return verifyDecryptResultBatchSafe(ctHashesUint, results, signatures);
     }
 
     function not(uint8 returnType, bytes32 input) internal returns (bytes32) {
@@ -3331,14 +3359,81 @@ library FHE {
         Impl.publishDecryptResult(eaddress.unwrap(input), uint256(uint160(result)), signature);
     }
 
-    /// @notice Publish multiple decrypt results in one transaction
-    /// @dev Amortizes base tx cost across multiple operations
-    function publishDecryptResultBatch(uint256[] memory ctHashes, uint256[] memory results, bytes[] memory signatures) internal {
-        bytes32[] memory ctHashesBytes32 = new bytes32[](ctHashes.length);
-        for (uint256 i = 0; i < ctHashes.length; i++) {
-            ctHashesBytes32[i] = bytes32(ctHashes[i]);
+    /// @notice Publish multiple ebool decrypt results in one transaction
+    function publishDecryptResultBatch(ebool[] memory inputs, bool[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(ebool.unwrap(inputs[i]));
+            resultsUint[i] = results[i] ? 1 : 0;
         }
-        Impl.publishDecryptResultBatch(ctHashesBytes32, results, signatures);
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Publish multiple euint8 decrypt results in one transaction
+    function publishDecryptResultBatch(euint8[] memory inputs, uint8[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint8.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Publish multiple euint16 decrypt results in one transaction
+    function publishDecryptResultBatch(euint16[] memory inputs, uint16[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint16.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Publish multiple euint32 decrypt results in one transaction
+    function publishDecryptResultBatch(euint32[] memory inputs, uint32[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint32.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Publish multiple euint64 decrypt results in one transaction
+    function publishDecryptResultBatch(euint64[] memory inputs, uint64[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint64.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Publish multiple euint128 decrypt results in one transaction
+    function publishDecryptResultBatch(euint128[] memory inputs, uint128[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint128.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Publish multiple eaddress decrypt results in one transaction
+    function publishDecryptResultBatch(eaddress[] memory inputs, address[] memory results, bytes[] memory signatures) internal {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(eaddress.unwrap(inputs[i]));
+            resultsUint[i] = uint256(uint160(results[i]));
+        }
+        Impl.publishDecryptResultBatch(ctHashes, resultsUint, signatures);
     }
 
     // ********** VERIFY DECRYPT RESULT ************* //
@@ -3387,6 +3482,85 @@ library FHE {
         return Impl.verifyDecryptResult(eaddress.unwrap(input), uint256(uint160(result)), signature);
     }
 
+    // ********** VERIFY DECRYPT RESULT BATCH ************* //
+
+    /// @notice Verify multiple ebool decrypt result signatures
+    function verifyDecryptResultBatch(ebool[] memory inputs, bool[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(ebool.unwrap(inputs[i]));
+            resultsUint[i] = results[i] ? 1 : 0;
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint8 decrypt result signatures
+    function verifyDecryptResultBatch(euint8[] memory inputs, uint8[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint8.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint16 decrypt result signatures
+    function verifyDecryptResultBatch(euint16[] memory inputs, uint16[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint16.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint32 decrypt result signatures
+    function verifyDecryptResultBatch(euint32[] memory inputs, uint32[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint32.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint64 decrypt result signatures
+    function verifyDecryptResultBatch(euint64[] memory inputs, uint64[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint64.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint128 decrypt result signatures
+    function verifyDecryptResultBatch(euint128[] memory inputs, uint128[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint128.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple eaddress decrypt result signatures
+    function verifyDecryptResultBatch(eaddress[] memory inputs, address[] memory results, bytes[] memory signatures) internal view returns (bool) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(eaddress.unwrap(inputs[i]));
+            resultsUint[i] = uint256(uint160(results[i]));
+        }
+        return Impl.verifyDecryptResultBatch(ctHashes, resultsUint, signatures);
+    }
+
     // ********** VERIFY DECRYPT RESULT SAFE ************* //
 
     /// @notice Verify a decrypt result signature without publishing (non-reverting)
@@ -3431,6 +3605,85 @@ library FHE {
     /// @notice Verify a decrypt result signature for an eaddress (non-reverting)
     function verifyDecryptResultSafe(eaddress input, address result, bytes memory signature) internal view returns (bool) {
         return Impl.verifyDecryptResultSafe(eaddress.unwrap(input), uint256(uint160(result)), signature);
+    }
+
+    // ********** VERIFY DECRYPT RESULT BATCH SAFE ************* //
+
+    /// @notice Verify multiple ebool decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(ebool[] memory inputs, bool[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(ebool.unwrap(inputs[i]));
+            resultsUint[i] = results[i] ? 1 : 0;
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint8 decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(euint8[] memory inputs, uint8[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint8.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint16 decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(euint16[] memory inputs, uint16[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint16.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint32 decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(euint32[] memory inputs, uint32[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint32.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint64 decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(euint64[] memory inputs, uint64[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint64.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple euint128 decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(euint128[] memory inputs, uint128[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(euint128.unwrap(inputs[i]));
+            resultsUint[i] = uint256(results[i]);
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
+    }
+
+    /// @notice Verify multiple eaddress decrypt result signatures (non-reverting)
+    function verifyDecryptResultBatchSafe(eaddress[] memory inputs, address[] memory results, bytes[] memory signatures) internal view returns (bool[] memory) {
+        uint256[] memory ctHashes = new uint256[](inputs.length);
+        uint256[] memory resultsUint = new uint256[](results.length);
+        for (uint256 i = 0; i < inputs.length; i++) {
+            ctHashes[i] = uint256(eaddress.unwrap(inputs[i]));
+            resultsUint[i] = uint256(uint160(results[i]));
+        }
+        return Impl.verifyDecryptResultBatchSafe(ctHashes, resultsUint, signatures);
     }
 }
 

--- a/contracts/ICofhe.sol
+++ b/contracts/ICofhe.sol
@@ -117,6 +117,8 @@ interface ITaskManager {
         uint256 result,
         bytes calldata signature
     ) external view returns (bool);
+    function verifyDecryptResultBatch(uint256[] calldata ctHashes, uint256[] calldata results, bytes[] calldata signatures) external view returns (bool);
+    function verifyDecryptResultBatchSafe(uint256[] calldata ctHashes, uint256[] calldata results, bytes[] calldata signatures) external view returns (bool[] memory);
 }
 
 library Utils {

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -617,6 +617,39 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         return _verifyDecryptResult(ctHash, result, signature, false);
     }
 
+    /// @notice Verify multiple decrypt result signatures without publishing
+    /// @dev Reverts if any signature is invalid
+    function verifyDecryptResultBatch(
+        uint256[] calldata ctHashes,
+        uint256[] calldata results,
+        bytes[] calldata signatures
+    ) external view returns (bool) {
+        uint256 length = ctHashes.length;
+        if (results.length != length || signatures.length != length) revert LengthMismatch();
+
+        for (uint256 i = 0; i < length; i++) {
+            _verifyDecryptResult(ctHashes[i], results[i], signatures[i], true);
+        }
+        return true;
+    }
+
+    /// @notice Verify multiple decrypt result signatures without publishing (non-reverting)
+    /// @dev Returns per-item results instead of reverting
+    function verifyDecryptResultBatchSafe(
+        uint256[] calldata ctHashes,
+        uint256[] calldata results,
+        bytes[] calldata signatures
+    ) external view returns (bool[] memory) {
+        uint256 length = ctHashes.length;
+        if (results.length != length || signatures.length != length) revert LengthMismatch();
+
+        bool[] memory validResults = new bool[](length);
+        for (uint256 i = 0; i < length; i++) {
+            validResults[i] = _verifyDecryptResult(ctHashes[i], results[i], signatures[i], false);
+        }
+        return validResults;
+    }
+
     /// @dev Verify decrypt result signature
     /// @dev Skips verification if decryptResultSigner is address(0) (debug mode)
     /// @param shouldRevert If true, reverts on invalid signature; if false, returns false

--- a/contracts/internal/host-chain/test/decryptResult/DecryptResult.behavior.ts
+++ b/contracts/internal/host-chain/test/decryptResult/DecryptResult.behavior.ts
@@ -366,6 +366,209 @@ export function shouldBehaveLikeDecryptResult(): void {
     });
   });
 
+  describe("verifyDecryptResultBatch", function () {
+    it("should return true for all valid signatures", async function () {
+      const taskManager = this.taskManager as Contract;
+      const testSigner = this.testSigner as Wallet;
+
+      const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
+      const count = 3;
+      const ctHashes: bigint[] = [];
+      const results: bigint[] = [];
+      const signatures: string[] = [];
+
+      for (let i = 0; i < count; i++) {
+        const baseHash = keccak256(toUtf8Bytes(`verify-batch-valid-${i}`));
+        const ctHash = buildCtHash(baseHash, EUINT64_TFHE);
+        const result = BigInt(i * 100 + 1);
+
+        const signature = await signDecryptResult(
+          testSigner,
+          result,
+          EUINT64_TFHE,
+          chainId,
+          ctHash
+        );
+
+        ctHashes.push(ctHash);
+        results.push(result);
+        signatures.push("0x" + signature);
+      }
+
+      const isValid = await taskManager.verifyDecryptResultBatch(
+        ctHashes,
+        results,
+        signatures
+      );
+      expect(isValid).to.be.true;
+    });
+
+    it("should not modify state (view function)", async function () {
+      const taskManager = this.taskManager as Contract;
+      const testSigner = this.testSigner as Wallet;
+
+      const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
+      const baseHash = keccak256(toUtf8Bytes("verify-batch-no-state"));
+      const ctHash = buildCtHash(baseHash, EUINT64_TFHE);
+      const result = BigInt(888);
+
+      const signature = await signDecryptResult(
+        testSigner,
+        result,
+        EUINT64_TFHE,
+        chainId,
+        ctHash
+      );
+
+      await taskManager.verifyDecryptResultBatch(
+        [ctHash],
+        [result],
+        ["0x" + signature]
+      );
+
+      const [, exists] = await taskManager.getDecryptResultSafe(ctHash);
+      expect(exists).to.be.false;
+    });
+
+    it("should revert if any signature is invalid", async function () {
+      const taskManager = this.taskManager as Contract;
+      const testSigner = this.testSigner as Wallet;
+
+      const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
+
+      const baseHash1 = keccak256(toUtf8Bytes("verify-batch-fail-1"));
+      const ctHash1 = buildCtHash(baseHash1, EUINT64_TFHE);
+      const result1 = BigInt(111);
+      const sig1 = await signDecryptResult(testSigner, result1, EUINT64_TFHE, chainId, ctHash1);
+
+      const baseHash2 = keccak256(toUtf8Bytes("verify-batch-fail-2"));
+      const ctHash2 = buildCtHash(baseHash2, EUINT64_TFHE);
+      const result2 = BigInt(222);
+
+      await expect(
+        taskManager.verifyDecryptResultBatch(
+          [ctHash1, ctHash2],
+          [result1, result2],
+          ["0x" + sig1, "0x" + "00".repeat(65)]
+        )
+      ).to.be.reverted;
+    });
+
+    it("should succeed with empty arrays", async function () {
+      const taskManager = this.taskManager as Contract;
+
+      const isValid = await taskManager.verifyDecryptResultBatch([], [], []);
+      expect(isValid).to.be.true;
+    });
+
+    it("should revert on length mismatch", async function () {
+      const taskManager = this.taskManager as Contract;
+
+      await expect(
+        taskManager.verifyDecryptResultBatch(
+          [BigInt(1), BigInt(2)],
+          [BigInt(10)],
+          ["0x" + "00".repeat(65)]
+        )
+      ).to.be.revertedWithCustomError(taskManager, "LengthMismatch");
+    });
+  });
+
+  describe("verifyDecryptResultBatchSafe", function () {
+    it("should return array of true for all valid signatures", async function () {
+      const taskManager = this.taskManager as Contract;
+      const testSigner = this.testSigner as Wallet;
+
+      const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
+      const count = 3;
+      const ctHashes: bigint[] = [];
+      const results: bigint[] = [];
+      const signatures: string[] = [];
+
+      for (let i = 0; i < count; i++) {
+        const baseHash = keccak256(toUtf8Bytes(`verify-batch-safe-valid-${i}`));
+        const ctHash = buildCtHash(baseHash, EUINT64_TFHE);
+        const result = BigInt(i * 100 + 1);
+
+        const signature = await signDecryptResult(
+          testSigner,
+          result,
+          EUINT64_TFHE,
+          chainId,
+          ctHash
+        );
+
+        ctHashes.push(ctHash);
+        results.push(result);
+        signatures.push("0x" + signature);
+      }
+
+      const validResults = await taskManager.verifyDecryptResultBatchSafe(
+        ctHashes,
+        results,
+        signatures
+      );
+      expect(validResults).to.have.length(count);
+      for (let i = 0; i < count; i++) {
+        expect(validResults[i]).to.be.true;
+      }
+    });
+
+    it("should return per-item results with mixed valid/invalid signatures", async function () {
+      const taskManager = this.taskManager as Contract;
+      const testSigner = this.testSigner as Wallet;
+
+      const chainId = BigInt((await ethers.provider.getNetwork()).chainId);
+
+      // First: valid
+      const baseHash1 = keccak256(toUtf8Bytes("verify-batch-safe-mixed-1"));
+      const ctHash1 = buildCtHash(baseHash1, EUINT64_TFHE);
+      const result1 = BigInt(111);
+      const sig1 = await signDecryptResult(testSigner, result1, EUINT64_TFHE, chainId, ctHash1);
+
+      // Second: invalid (wrong result)
+      const baseHash2 = keccak256(toUtf8Bytes("verify-batch-safe-mixed-2"));
+      const ctHash2 = buildCtHash(baseHash2, EUINT64_TFHE);
+      const result2 = BigInt(222);
+      const sig2 = await signDecryptResult(testSigner, BigInt(999), EUINT64_TFHE, chainId, ctHash2);
+
+      // Third: valid
+      const baseHash3 = keccak256(toUtf8Bytes("verify-batch-safe-mixed-3"));
+      const ctHash3 = buildCtHash(baseHash3, EUINT64_TFHE);
+      const result3 = BigInt(333);
+      const sig3 = await signDecryptResult(testSigner, result3, EUINT64_TFHE, chainId, ctHash3);
+
+      const validResults = await taskManager.verifyDecryptResultBatchSafe(
+        [ctHash1, ctHash2, ctHash3],
+        [result1, result2, result3],
+        ["0x" + sig1, "0x" + sig2, "0x" + sig3]
+      );
+
+      expect(validResults[0]).to.be.true;
+      expect(validResults[1]).to.be.false;
+      expect(validResults[2]).to.be.true;
+    });
+
+    it("should return empty array for empty input", async function () {
+      const taskManager = this.taskManager as Contract;
+
+      const validResults = await taskManager.verifyDecryptResultBatchSafe([], [], []);
+      expect(validResults).to.have.length(0);
+    });
+
+    it("should revert on length mismatch", async function () {
+      const taskManager = this.taskManager as Contract;
+
+      await expect(
+        taskManager.verifyDecryptResultBatchSafe(
+          [BigInt(1), BigInt(2)],
+          [BigInt(10)],
+          ["0x" + "00".repeat(65)]
+        )
+      ).to.be.revertedWithCustomError(taskManager, "LengthMismatch");
+    });
+  });
+
   describe("verifyDecryptResult", function () {
     it("should return true for valid signature", async function () {
       const taskManager = this.taskManager as Contract;


### PR DESCRIPTION
## Motivation
`publishDecryptResultBatch` only accepted raw `uint256[]`, making it cumbersome to use with typed handles. Additionally, there is no batch equivalent of `verifyDecryptResult` for read-only signature verification.

## Summary
- Add `verifyDecryptResultBatch` and `verifyDecryptResultBatchSafe` to TaskManager (view functions for batch signature verification)
- Add typed overloads for `publishDecryptResultBatch`, `verifyDecryptResultBatch`, and `verifyDecryptResultBatchSafe` in FHE.sol (per encrypted type: ebool, euint8-128, eaddress)
- Update ITaskManager interface with new batch verify functions
