### PR TITLE
fix(FHE): guard `getDecryptResult` and `getDecryptResultSafe` against uninitialized (zero) handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - `Utils.inputFromHashAndProof` no longer hardcodes `securityZone: 0`. A new 4-argument overload accepts an explicit `securityZone`, bringing it in line with the other `inputFrom*` helpers. The original 3-argument signature is kept as a backward-compatible wrapper defaulting to zone `0`. Fixes `verifyInput` failures when building an `EncryptedInput` from a hash and proof for a ciphertext on a non-zero security zone.
+- `FHE.getDecryptResult` and `FHE.getDecryptResultSafe` now guard against uninitialized (zero) ciphertext handles instead of forwarding them to the task manager: the reverting variant reverts early with a clear message, and the safe variant returns `(0, false)`.
 
 ## v0.1.4 - 2026-06-01
 

--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -132,10 +132,12 @@ library Impl {
     }
 
     function getDecryptResult(bytes32 input) internal view returns (uint256) {
+        require(Common.isInitialized(input), "FHE: getDecryptResult called with uninitialized handle");
         return ITaskManager(TASK_MANAGER_ADDRESS).getDecryptResult(uint256(input));
     }
 
     function getDecryptResultSafe(bytes32 input) internal view returns (uint256 result, bool decrypted) {
+        if (!Common.isInitialized(input)) return (0, false);
         return ITaskManager(TASK_MANAGER_ADDRESS).getDecryptResultSafe(uint256(input));
     }
 


### PR DESCRIPTION
## Summary

`Impl.getDecryptResult` and `Impl.getDecryptResultSafe` in `contracts/FHE.sol` accept any `bytes32` handle without checking whether it is initialized (non-zero). Passing a zero handle forwards `uint256(0)` to the task manager, which may coincidentally match a real pending or completed decrypt task at slot 0, returning a wrong plaintext the caller treats as valid.

## Bug

```solidity
// Before
function getDecryptResult(bytes32 input) internal view returns (uint256) {
    return ITaskManager(TASK_MANAGER_ADDRESS).getDecryptResult(uint256(input));
    // ↑ input == 0 → queries task slot 0 in the task manager
    //   If slot 0 holds a real completed task, caller receives its result silently.
}

function getDecryptResultSafe(bytes32 input) internal view returns (uint256 result, bool decrypted) {
    return ITaskManager(TASK_MANAGER_ADDRESS).getDecryptResultSafe(uint256(input));
    // ↑ same issue — may return (value, true) for slot 0
}
```

**Impact:** Contracts that accidentally call these functions with an uninitialized `euintX` field get a non-zero, apparently-valid result instead of an error. This can silently corrupt application state (e.g., a balance read from an uninitialized storage slot returns a non-zero plaintext).

## Fix

- `getDecryptResult`: revert with a clear message when the handle is zero.
- `getDecryptResultSafe`: return `(0, false)` (semantically "not yet decrypted") for zero handles, consistent with the function's safe semantics.

```solidity
function getDecryptResult(bytes32 input) internal view returns (uint256) {
    require(Common.isInitialized(input), "FHE: getDecryptResult called with uninitialized handle");
    ...
}

function getDecryptResultSafe(bytes32 input) internal view returns (uint256 result, bool decrypted) {
    if (!Common.isInitialized(input)) return (0, false);
    ...
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior on the decrypt-result read path; fixes silent wrong plaintext but any code that accidentally relied on zero-handle forwarding will now revert or get `(0, false)`.
> 
> **Overview**
> **`FHE.getDecryptResult` and `FHE.getDecryptResultSafe`** no longer forward a zero ciphertext handle to the task manager. A zero handle used to query task slot `0`, which could return another task’s plaintext and look valid to callers.
> 
> The reverting helper now **`require`s `Common.isInitialized(input)`** with an explicit revert message. The safe helper **returns `(0, false)`** for uninitialized handles, matching “not decrypted” semantics. **CHANGELOG** records the fix under Unreleased → Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b103afe7a04b5b96d1a849dea55b3abe7962d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->