### PR TITLE
fix(ICofhe): add `securityZone` parameter to `Utils.inputFromHashAndProof`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - **CommitmentRegistry** — UUPS-upgradeable contract for on-chain FHE computation commitments (`handle → commitHash`) grouped by state version. Threshold Network uses these to verify ciphertext integrity before decrypting. Includes version lifecycle state machine, write-once enforcement, batch posting, array-based enumeration with paginated cursor, and Arbitrum gas estimation script.
 
+### Fixed
+- `Utils.inputFromHashAndProof` no longer hardcodes `securityZone: 0`. A new 4-argument overload accepts an explicit `securityZone`, bringing it in line with the other `inputFrom*` helpers. The original 3-argument signature is kept as a backward-compatible wrapper defaulting to zone `0`. Fixes `verifyInput` failures when building an `EncryptedInput` from a hash and proof for a ciphertext on a non-zero security zone.
+
 ## v0.1.3 - 2025-03-25
 
 ### Changed

--- a/contracts/ICofhe.sol
+++ b/contracts/ICofhe.sol
@@ -246,13 +246,23 @@ library Utils {
         return v;
     }
 
-    function inputFromHashAndProof(bytes32 hash, bytes memory signature, uint8 utype) internal pure returns (EncryptedInput memory) {
+    function inputFromHashAndProof(
+        bytes32 hash,
+        bytes memory signature,
+        uint8 utype,
+        uint8 securityZone
+    ) internal pure returns (EncryptedInput memory) {
         return EncryptedInput({
             ctHash: uint256(hash),
-            securityZone: 0,
+            securityZone: securityZone,
             utype: utype,
             signature: signature
         });
+    }
+
+    /// @dev Convenience overload that defaults to securityZone 0.
+    function inputFromHashAndProof(bytes32 hash, bytes memory signature, uint8 utype) internal pure returns (EncryptedInput memory) {
+        return inputFromHashAndProof(hash, signature, utype, 0);
     }
 
     function expectUtype(uint8 actual, uint8 expected) internal pure {


### PR DESCRIPTION
## Summary

`Utils.inputFromHashAndProof` in `contracts/ICofhe.sol` always constructs an `EncryptedInput` with `securityZone: 0`, regardless of the actual security zone the ciphertext was created for. This silently breaks any caller that uses a non-zero security zone.

## Bug

```solidity
// Before
function inputFromHashAndProof(bytes32 hash, bytes memory signature, uint8 utype)
    internal pure returns (EncryptedInput memory)
{
    return EncryptedInput({
        ctHash: uint256(hash),
        securityZone: 0,    // ← always 0, ignores multi-zone configurations
        utype: utype,
        signature: signature
    });
}
```

**Impact:** When a ciphertext is created on security zone 1 (or any zone ≠ 0) and the caller builds its `EncryptedInput` via `inputFromHashAndProof`, the resulting struct has `securityZone: 0`. The CoFHE task manager then validates the input against zone 0's public key rather than zone 1's, causing `verifyInput` to fail with a cryptographic verification error that is difficult to diagnose.

All other `inputFrom*` helpers (`inputFromEuint8`, `inputFromEuint64`, etc.) correctly propagate `securityZone` from the input struct. `inputFromHashAndProof` is the only outlier.

## Fix

Add a four-argument overload that accepts an explicit `securityZone` parameter. The original three-argument signature is kept as a backward-compatible convenience wrapper defaulting to zone 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible change to a pure library helper; no auth, storage, or upgrade logic touched.
> 
> **Overview**
> **`Utils.inputFromHashAndProof`** no longer always sets **`securityZone`** to `0` when building an **`EncryptedInput`** from a hash and proof.
> 
> A new four-argument overload takes an explicit **`securityZone`**, matching the other **`inputFrom*`** helpers. The original three-argument form remains and forwards to zone `0`, so existing callers keep the same behavior.
> 
> This fixes **`verifyInput`** (and similar intake) failing for ciphertexts created on a non-zero security zone, where verification was incorrectly run against zone `0`’s keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a57b683568132f8c1e2ddeb453d3f33c2ffbb2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->