### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## v0.1.4 - 2026-06-01
 
 ### Added
 - **CommitmentRegistry** — UUPS-upgradeable contract for on-chain FHE computation commitments (`handle → commitHash`) grouped by state version. Threshold Network uses these to verify ciphertext integrity before decrypting. Includes version lifecycle state machine, write-once enforcement, batch posting, array-based enumeration with paginated cursor, and Arbitrum gas estimation script.
 
-## v0.1.3 - 2025-03-25
+### Changed
+- **External Inputs API** - External inputs are represented with named types
+
+## v0.1.3 - 2026-03-25
 
 ### Changed
 - Rename `FHE.asEbool(bytes32)`, `FHE.asEuint*(bytes32)`, `FHE.asEaddress(bytes32)` to `FHE.wrapEbool(bytes32)`, `FHE.wrapEuint*(bytes32)`, `FHE.wrapEaddress(bytes32)` to avoid overload ambiguity with `asEuintX(0)` calls and clarify intent
@@ -14,7 +17,7 @@
 - CI now compiles against local `cofhe-contracts` source instead of stale npm version, closing a gap where FHE.sol compilation errors were not caught
 - Update internal test contracts to match current FHE.sol API (remove `euint256`, `FHE.decrypt`, fix `bytes32` return types)
 
-## v0.1.2 - 2025-03-25 - DEPRECATED
+## v0.1.2 - 2026-03-25 - DEPRECATED
 
 ### Added
 - `FHE.isInitialized()` overloads for all encrypted types (`ebool`, `euint8`, `euint16`, `euint32`, `euint64`, `euint128`, `eaddress`) to check whether a ciphertext handle is initialized
@@ -25,11 +28,11 @@
 - Add typed overloads for `publishDecryptResultBatch`, `verifyDecryptResultBatch`, and `verifyDecryptResultBatchSafe` in FHE.sol (per encrypted type: ebool, euint8-128, eaddress)
 - Update ITaskManager interface with new batch verify functions
 
-## v0.1.1 - 2025-03-16
+## v0.1.1 - 2026-03-16
 
 - Remove decryption endpoints 
 
-## v0.1.0 - 2025-02-25
+## v0.1.0 - 2026-02-25
 
 ### Breaking Changes
 - **Ciphertext handle type change (`uint256` → `bytes32`)**: All encrypted types (`ebool`, `euint8`, `euint16`, `euint32`, `euint64`, `euint128`, `eaddress`) now use `bytes32` as their underlying type instead of `uint256`. This changes the ABI encoding of any function that accepts or returns encrypted types.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or contract code changes.
> 
> **Overview**
> Releases **v0.1.4** (2026-06-01) in the changelog, replacing the **Unreleased** section. The new release documents **CommitmentRegistry** (on-chain FHE commitment registry for threshold verification) and a **Changed** note that the **External Inputs API** now uses named types.
> 
> Release section headers for **v0.1.3**, **v0.1.2**, **v0.1.1**, and **v0.1.0** are updated from **2025** to **2026** dates so the version history is consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa1de9e5399c3ccd1aedfe56d3220034dafc8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->