### PR TITLE
Bump version from 0.1.3 to 0.1.4

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fhenixprotocol/cofhe-contracts",
 	"description": "Smart Contract Library for the CoFHE with FHE primitives",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"author": {
 		"name": "FhenixProtocol",
 		"url": "https://github.com/FhenixProtocol/cofhe-contracts"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no contract or dependency changes in the diff.
> 
> **Overview**
> Bumps the published npm package **`@fhenixprotocol/cofhe-contracts`** from **0.1.3** to **0.1.4** in `contracts/package.json`. No library source or API changes appear in this diff—only the semver for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9569d1ffc35c4dc32d4cbe55ea94cb15ed593b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->