### PR TITLE
fix contracts deployment

### DIFF
--- a/contracts/internal/host-chain/utils/fund.ts
+++ b/contracts/internal/host-chain/utils/fund.ts
@@ -23,13 +23,16 @@ export async function fundAccount(
 ): Promise<any> {
   if ((await hre.ethers.provider.getBalance(signer.address)).toString() === "0") {
     if (hre.network.name === "localfhenixk8s") {
-      // Local CoFHE hostchain now relies on prefunded genesis accounts instead of
-      // the old faucet service, so a zero balance here means the hostchain state
-      // was initialized from the wrong image/genesis and deployment cannot proceed.
-      throw new Error(
-        `Account ${signer.address} has zero balance on localfhenixk8s. ` +
-        "This devnet no longer exposes hostchain:3000/faucet; rebuild the hostchain image and wipe the hostchain/beacon volumes so the prefunded genesis accounts are applied."
-      );
+      const clientVersion: string = await hre.ethers.provider.send("web3_clientVersion", []);
+      if (clientVersion.toLowerCase().startsWith("anvil")) {
+        await hre.ethers.provider.send("anvil_setBalance", [
+          signer.address,
+          "0xD3C21BCECCEDA1000000", // 1M ETH
+        ]);
+        console.log(chalk.green("Account with address", signer.address, "funded via anvil_setBalance"));
+      } else {
+        await getFunds(signer.address, "http://hostchain:3000");
+      }
     } else if (hre.network.name === "localfhenix") {
       await hre.fhenixjs.getFunds(signer.address);
       console.log(

--- a/contracts/internal/host-chain/utils/updateTaskManagerAddress.ts
+++ b/contracts/internal/host-chain/utils/updateTaskManagerAddress.ts
@@ -35,14 +35,21 @@ export function updateTaskManagerAddressInSolidity(newProxyAddress: string) {
 }
 
 export async function updateTaskManagerAddressInJsonArtifact(newAddress: string, hre: HardhatRuntimeEnvironment) {
-  const filePath = path.join(
+  const artifactsDir = path.join(
     __dirname,
     `../ignition/deployments/chain-${await hre.getChainId()}/artifacts/`,
-    "DeterministicTM#DeterministicTM.json",
   );
+  const filePath = path.join(artifactsDir, "DeterministicTM#DeterministicTM.json");
 
-  let fileContent = fs.readFileSync(filePath, "utf8");
-  let json = JSON.parse(fileContent);
+  fs.mkdirSync(artifactsDir, { recursive: true });
+
+  let json: any;
+  if (fs.existsSync(filePath)) {
+    json = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } else {
+    // Ignition artifact was not written (e.g. create2 strategy on a fresh chain) — synthesise it
+    json = { address: newAddress };
+  }
   json.address = newAddress;
 
   // Write the updated content back to the file


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to Hardhat deployment helpers for local/k8s networks; no production auth, on-chain logic, or user-facing runtime behavior.
> 
> **Overview**
> Fixes **localfhenixk8s** contract deployment when deployer accounts start with zero balance and when Ignition does not emit the expected TaskManager artifact.
> 
> For **funding**, the previous behavior was to **fail fast** with a message about prefunded genesis and rebuilding images. The PR **detects the node** via `web3_clientVersion`: on **Anvil**, it funds the signer with **`anvil_setBalance`** (1M ETH); otherwise it calls the existing **`getFunds`** helper against **`http://hostchain:3000`**.
> 
> For **TaskManager address bookkeeping**, **`updateTaskManagerAddressInJsonArtifact`** now **creates** the chain-specific Ignition artifacts directory if needed, **reads** `DeterministicTM#DeterministicTM.json` when present, or **writes a minimal** `{ address }` object when the file is missing (e.g. create2 on a fresh chain), then updates the address and continues with the existing rename to `TaskManager#TaskManager.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2828a8b5d2513f11feda87d63c8bd25355e114a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->