### PR TITLE
[FEAT] TaskManager: optional owner-controlled access list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **TaskManager access list** — optional, owner-controlled allowlist that gates task intake (`createTask`, `createRandomTask`, `verifyInput`) to approved callers. Off by default, so behavior is unchanged on upgrade; the owner turns it on with `enableAccessList()` / off with `disableAccessList()`, and manages members via batch `addToAccessList` / `removeFromAccessList`. Intended for controlled early-mainnet rollout. ACL `allow*` and decrypt-result publishing are intentionally not gated (ACL is reachable only through gated intake, and decrypt publishing is signature-gated). New storage is appended (the toggle packs into an existing slot, the mapping takes the next), keeping UUPS upgrades storage-layout-compatible.
+
 ## v0.1.4 - 2026-06-01
 
 ### Added

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -32,6 +32,7 @@ error InvalidAddress();
 error OnlyOwnerAllowed(address caller);
 error OnlyAggregatorAllowed(address caller);
 error CofheIsUnavailable();
+error NotOnAccessList(address caller);
 
 
 // Operation-specific errors
@@ -204,6 +205,9 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
     event DecryptionResult(uint256 ctHash, uint256 result, address indexed requestor);
     event DecryptResultSignerChanged(address indexed oldSigner, address indexed newSigner);
     event VerifierSignerChanged(address indexed oldSigner, address indexed newSigner);
+    event AccessListEnabledSet(bool enabled);
+    event AccessGranted(address indexed account);
+    event AccessRevoked(address indexed account);
 
     struct Task {
         address creator;
@@ -240,6 +244,12 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
     // When set to address(0), signature verification is skipped (debug mode)
     address public decryptResultSigner;
 
+    // Optional, owner-controlled access list. Off by default (zero after upgrade) so behavior is
+    // unchanged until explicitly enabled. Declared here so the bool packs into the free trailing
+    // bytes of the slot shared with isEnabled/decryptResultSigner; the mapping takes the next slot.
+    bool public accessListEnabled;
+    mapping(address account => bool isAllowed) public accessList;
+
     modifier onlyAggregator() {
         if (!aggregators[msg.sender]) {
             revert OnlyAggregatorAllowed(msg.sender);
@@ -254,12 +264,48 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         _;
     }
 
+    // Gates task intake to allowlisted callers when the access list is enabled.
+    // Short-circuits when disabled, so the mapping is only read while the list is active.
+    modifier onlyAccessListed() {
+        if (accessListEnabled && !accessList[msg.sender]) {
+            revert NotOnAccessList(msg.sender);
+        }
+        _;
+    }
+
     function enable() external onlyOwner {
         isEnabled = true;
     }
 
     function disable() external onlyOwner {
         isEnabled = false;
+    }
+
+    function enableAccessList() external onlyOwner {
+        accessListEnabled = true;
+        emit AccessListEnabledSet(true);
+    }
+
+    function disableAccessList() external onlyOwner {
+        accessListEnabled = false;
+        emit AccessListEnabledSet(false);
+    }
+
+    function addToAccessList(address[] calldata accounts) external onlyOwner {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            if (accounts[i] == address(0)) {
+                revert InvalidAddress();
+            }
+            accessList[accounts[i]] = true;
+            emit AccessGranted(accounts[i]);
+        }
+    }
+
+    function removeFromAccessList(address[] calldata accounts) external onlyOwner {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            accessList[accounts[i]] = false;
+            emit AccessRevoked(accounts[i]);
+        }
     }
 
     function sendEventCreated(uint256 ctHash, string memory operation, uint256[] memory inputs) private onlyIfEnabled {
@@ -483,7 +529,7 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         }
     }
 
-    function createRandomTask(uint8 returnType, uint256 seed, int32 securityZone) external returns (uint256) {
+    function createRandomTask(uint8 returnType, uint256 seed, int32 securityZone) external onlyAccessListed returns (uint256) {
         if (!isValidType(returnType)) {
             revert UnsupportedType(returnType);
         }
@@ -513,7 +559,7 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         }
     }
 
-    function createTask(uint8 returnType, FunctionId funcId, uint256[] memory encryptedHashes, uint256[] memory extraInputs) external returns (uint256) {
+    function createTask(uint8 returnType, FunctionId funcId, uint256[] memory encryptedHashes, uint256[] memory extraInputs) external onlyAccessListed returns (uint256) {
         if (funcId == FunctionId.random) {
             revert RandomFunctionNotSupported();
         }
@@ -714,7 +760,7 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
         return result;
     }
 
-    function verifyInput(EncryptedInput memory input, address sender) external returns (uint256) {
+    function verifyInput(EncryptedInput memory input, address sender) external onlyAccessListed returns (uint256) {
         int32 securityZone = int32(uint32(input.securityZone));
 
         // When signer is set to 0 address we skip this logic to be able to support debug use cases.

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -244,9 +244,7 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
     // When set to address(0), signature verification is skipped (debug mode)
     address public decryptResultSigner;
 
-    // Optional, owner-controlled access list. Off by default (zero after upgrade) so behavior is
-    // unchanged until explicitly enabled. Declared here so the bool packs into the free trailing
-    // bytes of the slot shared with isEnabled/decryptResultSigner; the mapping takes the next slot.
+    // Optional, owner-controlled access list, off by default (no behavior change until enabled).
     bool public accessListEnabled;
     mapping(address account => bool isAllowed) public accessList;
 

--- a/contracts/internal/host-chain/contracts/TaskManager.sol
+++ b/contracts/internal/host-chain/contracts/TaskManager.sol
@@ -301,6 +301,9 @@ contract TaskManager is ITaskManager, Initializable, UUPSUpgradeable, Ownable2St
 
     function removeFromAccessList(address[] calldata accounts) external onlyOwner {
         for (uint256 i = 0; i < accounts.length; i++) {
+            if (accounts[i] == address(0)) {
+                revert InvalidAddress();
+            }
             accessList[accounts[i]] = false;
             emit AccessRevoked(accounts[i]);
         }

--- a/contracts/internal/host-chain/package.json
+++ b/contracts/internal/host-chain/package.json
@@ -8,6 +8,7 @@
     "test:localfhenix": "hardhat test",
     "test:decrypt-result:localfhenix": "hardhat test test/decryptResult/DecryptResult.ts",
     "test:onchain": "hardhat test test/onChain/OnChain.ts",
+    "test:access-list": "hardhat test test/accessList/AccessList.ts --network hardhat",
     "clean": "rimraf ./artifacts ./cache ./coverage ./types ./coverage.json ./deployments/localfhenix ./ignition/deployments ./.openzeppelin/*",
     "compile": "hardhat compile",
     "task:deploy": "hardhat deploy",

--- a/contracts/internal/host-chain/storage-layout-snapshot.json
+++ b/contracts/internal/host-chain/storage-layout-snapshot.json
@@ -10,7 +10,7 @@
           "slot": "0",
           "type": "t_bool",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:155"
+          "src": "contracts/TaskManager.sol:156"
         },
         {
           "label": "securityZoneMax",
@@ -18,7 +18,7 @@
           "slot": "0",
           "type": "t_int32",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:215"
+          "src": "contracts/TaskManager.sol:219"
         },
         {
           "label": "securityZoneMin",
@@ -26,7 +26,7 @@
           "slot": "0",
           "type": "t_int32",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:216"
+          "src": "contracts/TaskManager.sol:220"
         },
         {
           "label": "randomCounter",
@@ -34,7 +34,7 @@
           "slot": "1",
           "type": "t_uint256",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:219"
+          "src": "contracts/TaskManager.sol:223"
         },
         {
           "label": "unusedAggregator",
@@ -42,15 +42,15 @@
           "slot": "2",
           "type": "t_address",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:221"
+          "src": "contracts/TaskManager.sol:225"
         },
         {
           "label": "acl",
           "offset": 0,
           "slot": "3",
-          "type": "t_contract(ACL)25384",
+          "type": "t_contract(ACL)27249",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:224"
+          "src": "contracts/TaskManager.sol:228"
         },
         {
           "label": "verifierSigner",
@@ -58,7 +58,7 @@
           "slot": "4",
           "type": "t_address",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:226"
+          "src": "contracts/TaskManager.sol:230"
         },
         {
           "label": "version",
@@ -66,15 +66,15 @@
           "slot": "4",
           "type": "t_uint8",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:228"
+          "src": "contracts/TaskManager.sol:232"
         },
         {
           "label": "plaintextsStorage",
           "offset": 0,
           "slot": "5",
-          "type": "t_contract(PlaintextsStorage)25814",
+          "type": "t_contract(PlaintextsStorage)27679",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:231"
+          "src": "contracts/TaskManager.sol:235"
         },
         {
           "label": "aggregators",
@@ -82,7 +82,7 @@
           "slot": "6",
           "type": "t_mapping(t_address,t_bool)",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:233"
+          "src": "contracts/TaskManager.sol:237"
         },
         {
           "label": "isEnabled",
@@ -90,7 +90,7 @@
           "slot": "7",
           "type": "t_bool",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:237"
+          "src": "contracts/TaskManager.sol:241"
         },
         {
           "label": "decryptResultSigner",
@@ -98,7 +98,23 @@
           "slot": "7",
           "type": "t_address",
           "contract": "TaskManager",
-          "src": "contracts/TaskManager.sol:241"
+          "src": "contracts/TaskManager.sol:245"
+        },
+        {
+          "label": "accessListEnabled",
+          "offset": 21,
+          "slot": "7",
+          "type": "t_bool",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:250"
+        },
+        {
+          "label": "accessList",
+          "offset": 0,
+          "slot": "8",
+          "type": "t_mapping(t_address,t_bool)",
+          "contract": "TaskManager",
+          "src": "contracts/TaskManager.sol:251"
         }
       ],
       "types": {
@@ -110,11 +126,11 @@
           "label": "bool",
           "numberOfBytes": "1"
         },
-        "t_contract(ACL)25384": {
+        "t_contract(ACL)27249": {
           "label": "contract ACL",
           "numberOfBytes": "20"
         },
-        "t_contract(PlaintextsStorage)25814": {
+        "t_contract(PlaintextsStorage)27679": {
           "label": "contract PlaintextsStorage",
           "numberOfBytes": "20"
         },
@@ -301,7 +317,7 @@
           "label": "plaintextResults",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint256,t_struct(PlaintextResult)25715_storage)",
+          "type": "t_mapping(t_uint256,t_struct(PlaintextResult)27580_storage)",
           "contract": "PlaintextsStorage",
           "src": "contracts/PlaintextsStorage.sol:13"
         }
@@ -311,11 +327,11 @@
           "label": "bool",
           "numberOfBytes": "1"
         },
-        "t_mapping(t_uint256,t_struct(PlaintextResult)25715_storage)": {
+        "t_mapping(t_uint256,t_struct(PlaintextResult)27580_storage)": {
           "label": "mapping(uint256 => struct PlaintextsStorage.PlaintextResult)",
           "numberOfBytes": "32"
         },
-        "t_struct(PlaintextResult)25715_storage": {
+        "t_struct(PlaintextResult)27580_storage": {
           "label": "struct PlaintextsStorage.PlaintextResult",
           "members": [
             {

--- a/contracts/internal/host-chain/test/accessList/AccessList.ts
+++ b/contracts/internal/host-chain/test/accessList/AccessList.ts
@@ -83,8 +83,10 @@ describe("TaskManager access list", function () {
       .to.be.revertedWithCustomError(taskManager, "OwnableUnauthorizedAccount");
   });
 
-  it("rejects the zero address when adding", async function () {
+  it("rejects the zero address when adding or removing", async function () {
     await expect(taskManager.connect(owner).addToAccessList([hre.ethers.ZeroAddress]))
+      .to.be.revertedWithCustomError(taskManager, "InvalidAddress");
+    await expect(taskManager.connect(owner).removeFromAccessList([hre.ethers.ZeroAddress]))
       .to.be.revertedWithCustomError(taskManager, "InvalidAddress");
   });
 

--- a/contracts/internal/host-chain/test/accessList/AccessList.ts
+++ b/contracts/internal/host-chain/test/accessList/AccessList.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+import hre from "hardhat";
+import type { Contract } from "ethers";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployOnChainFixture } from "../onChain/OnChain.fixture";
+
+const TASK_MANAGER_ADDRESS = "0xeA30c4B8b44078Bbf8a6ef5b9f1eC1626C7848D9";
+
+// A valid euint8 return type and security zone within the fixture's configured range (-128..127).
+const EUINT8 = 2;
+const SECURITY_ZONE = 0;
+
+// Dummy EncryptedInput; the access-list gate runs before input validation, so the
+// contents are irrelevant for the blocked-path assertions.
+const DUMMY_INPUT = { ctHash: 1n, securityZone: 0, utype: EUINT8, signature: "0x" };
+
+describe("TaskManager access list", function () {
+  let taskManager: Contract;
+  let owner: HardhatEthersSigner;
+  let other: HardhatEthersSigner;
+
+  before(async function () {
+    await deployOnChainFixture();
+    [owner, other] = await hre.ethers.getSigners();
+    taskManager = await hre.ethers.getContractAt("TaskManager", TASK_MANAGER_ADDRESS);
+  });
+
+  // Reset to a clean baseline (disabled, `other` not listed) so tests are order-independent.
+  beforeEach(async function () {
+    await taskManager.connect(owner).disableAccessList();
+    await taskManager.connect(owner).removeFromAccessList([other.address]);
+  });
+
+  it("is disabled by default and lets any caller create tasks", async function () {
+    expect(await taskManager.accessListEnabled()).to.equal(false);
+    expect(await taskManager.accessList(other.address)).to.equal(false);
+    await expect(taskManager.connect(other).createRandomTask(EUINT8, 1, SECURITY_ZONE)).to.not.be.reverted;
+  });
+
+  it("blocks non-listed callers on all three intake functions when enabled", async function () {
+    await taskManager.connect(owner).enableAccessList();
+
+    await expect(taskManager.connect(other).createRandomTask(EUINT8, 1, SECURITY_ZONE))
+      .to.be.revertedWithCustomError(taskManager, "NotOnAccessList")
+      .withArgs(other.address);
+
+    await expect(taskManager.connect(other).createTask(EUINT8, 8 /* add */, [1n, 2n], []))
+      .to.be.revertedWithCustomError(taskManager, "NotOnAccessList")
+      .withArgs(other.address);
+
+    await expect(taskManager.connect(other).verifyInput(DUMMY_INPUT, other.address))
+      .to.be.revertedWithCustomError(taskManager, "NotOnAccessList")
+      .withArgs(other.address);
+  });
+
+  it("lets a listed caller through, and re-blocks after removal", async function () {
+    await taskManager.connect(owner).enableAccessList();
+
+    await taskManager.connect(owner).addToAccessList([other.address]);
+    expect(await taskManager.accessList(other.address)).to.equal(true);
+    await expect(taskManager.connect(other).createRandomTask(EUINT8, 1, SECURITY_ZONE)).to.not.be.reverted;
+
+    await taskManager.connect(owner).removeFromAccessList([other.address]);
+    await expect(taskManager.connect(other).createRandomTask(EUINT8, 1, SECURITY_ZONE))
+      .to.be.revertedWithCustomError(taskManager, "NotOnAccessList")
+      .withArgs(other.address);
+  });
+
+  it("reopens to everyone once disabled again", async function () {
+    await taskManager.connect(owner).enableAccessList();
+    await taskManager.connect(owner).disableAccessList();
+    await expect(taskManager.connect(other).createRandomTask(EUINT8, 1, SECURITY_ZONE)).to.not.be.reverted;
+  });
+
+  it("restricts every admin function to the owner", async function () {
+    await expect(taskManager.connect(other).enableAccessList())
+      .to.be.revertedWithCustomError(taskManager, "OwnableUnauthorizedAccount");
+    await expect(taskManager.connect(other).disableAccessList())
+      .to.be.revertedWithCustomError(taskManager, "OwnableUnauthorizedAccount");
+    await expect(taskManager.connect(other).addToAccessList([other.address]))
+      .to.be.revertedWithCustomError(taskManager, "OwnableUnauthorizedAccount");
+    await expect(taskManager.connect(other).removeFromAccessList([other.address]))
+      .to.be.revertedWithCustomError(taskManager, "OwnableUnauthorizedAccount");
+  });
+
+  it("rejects the zero address when adding", async function () {
+    await expect(taskManager.connect(owner).addToAccessList([hre.ethers.ZeroAddress]))
+      .to.be.revertedWithCustomError(taskManager, "InvalidAddress");
+  });
+
+  it("emits events on toggle and membership changes", async function () {
+    await expect(taskManager.connect(owner).enableAccessList())
+      .to.emit(taskManager, "AccessListEnabledSet").withArgs(true);
+    await expect(taskManager.connect(owner).disableAccessList())
+      .to.emit(taskManager, "AccessListEnabledSet").withArgs(false);
+    await expect(taskManager.connect(owner).addToAccessList([other.address]))
+      .to.emit(taskManager, "AccessGranted").withArgs(other.address);
+    await expect(taskManager.connect(owner).removeFromAccessList([other.address]))
+      .to.emit(taskManager, "AccessRevoked").withArgs(other.address);
+  });
+
+  it("supports batch add in a single call", async function () {
+    const [, , third] = await hre.ethers.getSigners();
+    await taskManager.connect(owner).addToAccessList([other.address, third.address]);
+    expect(await taskManager.accessList(other.address)).to.equal(true);
+    expect(await taskManager.accessList(third.address)).to.equal(true);
+    await taskManager.connect(owner).removeFromAccessList([other.address, third.address]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional, owner-controlled access list to `TaskManager` so we can opt in which callers may use the coprocessor during early-mainnet rollout. It is **off by default** — behavior is identical to today until the owner explicitly turns it on.

## What it does

- New owner-only controls:
  - `enableAccessList()` / `disableAccessList()` — master toggle (off by default).
  - `addToAccessList(address[])` / `removeFromAccessList(address[])` — batch membership management (one tx to onboard many).
- When enabled, task **intake** is restricted to allowlisted callers via a new `onlyAccessListed` modifier on `createTask`, `createRandomTask`, and `verifyInput`. Non-listed callers revert with `NotOnAccessList`.
- Events: `AccessListEnabledSet(bool)`, `AccessGranted(address)`, `AccessRevoked(address)`. Membership is reconstructable off-chain from events (no on-chain enumeration, for gas).

The allowlisted unit is `msg.sender` — i.e. the integrating contract, since `FHE.sol` is inlined into the caller.

## Why only intake

Intake is the single choke point where coprocessor compute originates. We deliberately do **not** gate:

- **ACL `allow*`** — `ACL` is reachable only through `TaskManager` (it reverts `DirectAllowForbidden` otherwise), and each `allow*` requires the caller to already be `isAllowed` on the handle, which is only obtainable via gated intake. So gating intake transitively covers it; gating the wrappers too would just add a cold SLOAD per call for redundant protection.
- **decrypt-result publishing** — protected by the threshold-network signature, not by caller identity. Gating it would only restrict relayers and is orthogonal to "who can use CoFHE."

## Upgrade safety

- New storage is appended after `decryptResultSigner`: `accessListEnabled` (bool) packs into the free trailing bytes of the existing slot (slot 7, offset 21) and `accessList` (mapping) takes the next slot (8). No existing variable moves.
- `pnpm storage-layout:check` reports `TaskManager — storage layout is upgrade-compatible`; the committed snapshot is regenerated in this PR.
- After upgrade the new storage reads as zero → access list **off** → no behavior change. No reinitializer needed.

## Gas

`createTask` already loads slot 7 (via `onlyIfEnabled`), so the toggle read is a warm SLOAD (~100 gas) when the list is off — effectively free on the hot path. `createRandomTask` / `verifyInput` take a single cold SLOAD for the toggle.

## Enabling on mainnet

1. `addToAccessList([...])` with the approved dapp contracts.
2. `enableAccessList()`.
3. `disableAccessList()` reopens to everyone (membership is preserved for re-enabling).

## Tests

New `test/accessList/AccessList.ts` (8 cases): default-off, blocked-when-enabled across all 3 intake functions, listed-caller passes + re-block on removal, reopen on disable, owner-only admin, zero-address rejection, events, and batch add. Full host-chain suite: **49 passing**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Gates core coprocessor intake on owner-managed membership; misconfiguration or a compromised owner could block integrators, though default-off and disable preserve an escape hatch.
> 
> **Overview**
> Adds an **optional, owner-controlled allowlist** on `TaskManager` so early mainnet can restrict who can start coprocessor work. The list is **off by default**; upgrades keep prior behavior until the owner calls `enableAccessList()`.
> 
> When enabled, **`onlyAccessListed`** gates task intake on `createTask`, `createRandomTask`, and `verifyInput` (`msg.sender` must be on `accessList` or the call reverts with `NotOnAccessList`). Owner-only **`enableAccessList` / `disableAccessList`** and batch **`addToAccessList` / `removeFromAccessList`** manage membership, with toggle and grant/revoke events. ACL `allow*` and decrypt-result publishing are **unchanged**.
> 
> New state **`accessListEnabled`** (packed in slot 7) and **`accessList`** mapping (slot 8) are appended for UUPS layout compatibility; the storage snapshot and changelog are updated. New Hardhat coverage in `test/accessList/AccessList.ts` plus `test:access-list` script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824e7b2f91ed8e9f21191f70462e5bae5d7a37de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->